### PR TITLE
[Frontend]: Styled About section in landing Page

### DIFF
--- a/client/css/pages/landing/about.css
+++ b/client/css/pages/landing/about.css
@@ -1,1 +1,36 @@
 /* About Section - Block: .about */
+
+.about-section {
+  background-color: var(--color-purple-900);/* Deep purple background */
+}
+
+.about-section-Ekehi-text{font-style: italic;}
+
+
+
+
+/* Responsive across mobile and desktop screens */
+@media (max-width: 768px) {
+
+  .about-section{
+    flex-direction: column;
+    gap: var(--space-10);
+  }
+
+  .about-section-title{
+    flex: none;
+  }
+
+  .about-section-description{
+    padding-inline: 0;
+  }
+
+}
+
+
+@media (max-width: 375px) {
+  .about-section-title{
+    font-size: 35px;
+  }
+}
+

--- a/client/css/pages/landing/about.css
+++ b/client/css/pages/landing/about.css
@@ -4,7 +4,7 @@
   background-color: var(--color-purple-900);/* Deep purple background */
 }
 
-.about-section-Ekehi-text{font-style: italic;}
+.about-section__title--ekehi{font-style: italic;}
 
 
 
@@ -17,11 +17,11 @@
     gap: var(--space-10);
   }
 
-  .about-section-title{
+  .about-section__title{
     flex: none;
   }
 
-  .about-section-description{
+  .about-section__description{
     padding-inline: 0;
   }
 
@@ -29,7 +29,7 @@
 
 
 @media (max-width: 375px) {
-  .about-section-title{
+  .about-section__title{
     font-size: 35px;
   }
 }

--- a/client/pages/index.html
+++ b/client/pages/index.html
@@ -56,13 +56,13 @@
 <section class="about-section px-16 flex py-16">
     
      <!-- Left column: Title -->
-    <h2 class="about-section-title text-5xl leading-tight text-inverse flex-1">
+    <h2 class="about-section__title text-5xl leading-tight text-inverse flex-1">
       <span class="font-sans">About</span>
-      <span class="about-section-Ekehi-text font-serif">Ekehi</span>
+      <span class="about-section__title--ekehi font-serif">Ekehi</span>
     </h2>
 
     <!-- Right column: Content -->
-    <div class="about-section-description flex flex-col gap-5 self-end flex-1 px-16">
+    <div class="about-section__description flex flex-col gap-5 self-end flex-1 px-16">
       <p class="text-inverse text-sm font-light">
                 Ekehi is a business intelligence platform for women entrepreneurs and
                 SME owners &#8212; providing a searchable database of active funding

--- a/client/pages/index.html
+++ b/client/pages/index.html
@@ -50,21 +50,36 @@
       <div></div>
     </header>
 
-    <!-- About Section -->
-    <section>
-      <h2>About Ekehi</h2>
-      <div>
-        <p>
-          Ekehi is a business intelligent platform for women entreprenuers and
-          SME owners &#x2014; providing a searchable database of active funding
-          opportunities (VCs, grants, loans, credit schemes), business training
-          programmes, and growth resources, all filterable by sector, stage,
-          location and funding size.
-        </p>
 
-        <button>Learn more</button>
-      </div>
-    </section>
+
+<!-- About Section --> 
+<section class="about-section px-16 flex py-16">
+    
+     <!-- Left column: Title -->
+    <h2 class="about-section-title text-5xl leading-tight text-inverse flex-1">
+      <span class="font-sans">About</span>
+      <span class="about-section-Ekehi-text font-serif">Ekehi</span>
+    </h2>
+
+    <!-- Right column: Content -->
+    <div class="about-section-description flex flex-col gap-5 self-end flex-1 px-16">
+      <p class="text-inverse text-sm font-light">
+                Ekehi is a business intelligence platform for women entrepreneurs and
+                SME owners &#8212; providing a searchable database of active funding
+                opportunities (VCs, grants, loans, credit schemes), business training
+                programmes, and growth resources, all filterable by sector, stage,
+                location and funding size.
+      </p>
+
+      <a href="#" class="btn btn--secondary self-start">
+        Learn more
+      </a>
+    </div>
+  
+</section>
+
+
+
 
     <section>
       <div>


### PR DESCRIPTION
TASK DESCRIPTION

<img width="1920" height="425" alt="Ekehi about desktop" src="https://github.com/user-attachments/assets/d2403467-6c0a-4855-bc98-820b1efeb8df" />
<img width="1917" height="727" alt="Ekehi about mobile 2" src="https://github.com/user-attachments/assets/1f3ebe62-3c28-42d6-8ba0-f7bd63458272" />


### **Structure of content**
The about section styling covers:

Deep purple section background
Two-column layout (heading left, content right)
Heading typography — "About" in sans, "Ekehi" in italic
Body text colour — light/white against the dark background
"Learn more" CTA button — white pill style
Responsive layout — single column on mobile


### **Type of Change**
Feature ✅
Bug fix
Documentation
Chore / refactor

### Linked Issue
Closes https://github.com/Tabi-Project/Ekehi/issues/22