### PR TITLE
[frontend] fix: add deselection support to Dropdown component

### DIFF
--- a/client/shared/components/dropdown/dropdown.js
+++ b/client/shared/components/dropdown/dropdown.js
@@ -58,6 +58,8 @@ class Dropdown {
     trigger.setAttribute("aria-haspopup", "listbox");
     trigger.setAttribute("aria-expanded", "false");
 
+    let currentValue = selected ?? null;
+
     const labelEl = document.createElement("span");
     labelEl.className = "dropdown__label";
     labelEl.textContent = selected
@@ -86,19 +88,30 @@ class Dropdown {
       btn.textContent = optLabel;
 
       btn.addEventListener("click", () => {
-        // Update label
-        labelEl.textContent = optLabel;
+        const isAlreadySelected = currentValue === value;
 
-        // Update selected state
-        panel.querySelectorAll(".dropdown__option").forEach((o) => {
-          o.setAttribute(
-            "aria-selected",
-            o.dataset.value === value ? "true" : "false",
-          );
-        });
-
-        Dropdown.#closeAll();
-        if (onChange) onChange(value, optLabel);
+        if (isAlreadySelected) {
+          // Deselect
+          currentValue = null;
+          labelEl.textContent = label;
+          panel.querySelectorAll(".dropdown__option").forEach((o) => {
+            o.setAttribute("aria-selected", "false");
+          });
+          Dropdown.#closeAll();
+          if (onChange) onChange(null, null);
+        } else {
+          // Select
+          currentValue = value;
+          labelEl.textContent = optLabel;
+          panel.querySelectorAll(".dropdown__option").forEach((o) => {
+            o.setAttribute(
+              "aria-selected",
+              o.dataset.value === value ? "true" : "false",
+            );
+          });
+          Dropdown.#closeAll();
+          if (onChange) onChange(value, optLabel);
+        }
       });
 
       panel.appendChild(btn);


### PR DESCRIPTION
## Summary
Clicking an already-selected dropdown option had no effect — there was no way to clear a selection once made.

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Linked Issue
Closes #68

## Changes Made
- Added `currentValue` variable to track the active selection
- Clicking an already-selected option now deselects it, resets the label to the placeholder, and calls `onChange(null, null)`

## Screenshots (for UI changes)
<!-- Add before/after screenshots or a screen recording -->

## Checklist
- [x] Branch is up to date with `development`
- [x] Code follows project conventions
- [x] No `.env` or secrets committed
- [x] UI changes tested on mobile and desktop
- [ ] Backend changes tested locally
- [x] PR is linked to an issue or ClickUp task