### PR TITLE
[frontend] refactor: migrate client-side JS to ES modules

### DIFF
--- a/client/contributors/contributors.js
+++ b/client/contributors/contributors.js
@@ -1,6 +1,7 @@
-// Must match [data-variant] values in contributors.css
-const CARD_VARIANTS = ["blue", "pink", "purple", "green", "yellow"];
+import "/shared/components/nav/nav.js";
+import "/shared/components/footer/footer.js";
 
+const CARD_VARIANTS = ["blue", "pink", "purple", "green", "yellow"];
 const CONTRIBUTORS_CONTAINER_ID = "contributors-grid";
 
 const contributors = [
@@ -72,7 +73,7 @@ const contributors = [
   },
 ];
 
-function createCardImage({ name, image, imageFit, style }) {
+function createCardImage({ name, image, style }) {
   const figure = document.createElement("figure");
   figure.className = "contributor-card__display";
 
@@ -81,7 +82,6 @@ function createCardImage({ name, image, imageFit, style }) {
     img.className = "contributor-card__image";
     img.src = image;
     img.alt = name;
-
     if (style) Object.assign(img.style, style);
     figure.append(img);
   }
@@ -105,7 +105,6 @@ function createContributorCard(contributor, variant) {
   const card = document.createElement("article");
   card.className = "contributor-card flex flex-col gap-0-5";
   card.dataset.variant = variant;
-
   card.append(createCardImage(contributor), ...createCardMeta(contributor));
   return card;
 }
@@ -115,7 +114,6 @@ function renderContributors(data, containerId) {
   if (!container) return;
 
   const fragment = document.createDocumentFragment();
-
   data.forEach((contributor, index) => {
     const variant = CARD_VARIANTS[index % CARD_VARIANTS.length];
     fragment.appendChild(createContributorCard(contributor, variant));
@@ -124,6 +122,4 @@ function renderContributors(data, containerId) {
   container.appendChild(fragment);
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  renderContributors(contributors, CONTRIBUTORS_CONTAINER_ID);
-});
+renderContributors(contributors, CONTRIBUTORS_CONTAINER_ID);

--- a/client/contributors/index.html
+++ b/client/contributors/index.html
@@ -50,10 +50,6 @@
     </main>
 
     <footer id="footer-root" class="footer"></footer>
-    <script src="/shared/services/api.js"></script>
-    <script src="/shared/services/auth.service.js"></script>
-    <script src="/shared/components/button/button.js"></script>
-    <script src="/shared/components/nav/nav.js"></script>
-    <script src="/shared/components/footer/footer.js"></script>
+    <script type="module" src="contributors.js"></script>
   </body>
 </html>

--- a/client/contributors/index.html
+++ b/client/contributors/index.html
@@ -50,6 +50,8 @@
     </main>
 
     <footer id="footer-root" class="footer"></footer>
+    <script src="/shared/services/api.js"></script>
+    <script src="/shared/services/auth.service.js"></script>
     <script src="/shared/components/button/button.js"></script>
     <script src="/shared/components/nav/nav.js"></script>
     <script src="/shared/components/footer/footer.js"></script>

--- a/client/index.html
+++ b/client/index.html
@@ -240,6 +240,8 @@
     </section>
 
     <footer id="footer-root" class="footer"></footer>
+    <script src="/shared/services/api.js"></script>
+    <script src="/shared/services/auth.service.js"></script>
     <script src="/shared/components/button/button.js"></script>
     <script src="/shared/components/nav/nav.js"></script>
     <script src="/shared/components/footer/footer.js"></script>

--- a/client/index.html
+++ b/client/index.html
@@ -240,11 +240,6 @@
     </section>
 
     <footer id="footer-root" class="footer"></footer>
-    <script src="/shared/services/api.js"></script>
-    <script src="/shared/services/auth.service.js"></script>
-    <script src="/shared/components/button/button.js"></script>
-    <script src="/shared/components/nav/nav.js"></script>
-    <script src="/shared/components/footer/footer.js"></script>
-    <script src="/landing/landing.js"></script>
+    <script type="module" src="/landing/landing.js"></script>
   </body>
 </html>

--- a/client/landing/landing.js
+++ b/client/landing/landing.js
@@ -1,3 +1,7 @@
+import Button from "/shared/components/button/button.js";
+import "/shared/components/nav/nav.js";
+import "/shared/components/footer/footer.js";
+
 const heroBtns = document.querySelector(".hero__btns");
 const aboutBtnMount = document.querySelector(".about-btn-mount");
 const ctaBtnMount = document.querySelector(".cta-btn-mount");

--- a/client/login/index.html
+++ b/client/login/index.html
@@ -39,12 +39,6 @@
     </main>
 
     <footer id="footer-root" class="footer"></footer>
-    <script src="/shared/services/api.js"></script>
-    <script src="/shared/services/auth.service.js"></script>
-    <script src="/shared/components/button/button.js"></script>
-    <script src="/shared/components/input/input.js"></script>
-    <script src="/shared/components/nav/nav.js"></script>
-    <script src="/shared/components/footer/footer.js"></script>
-    <script src="login.js"></script>
+    <script type="module" src="login.js"></script>
   </body>
 </html>

--- a/client/login/login.js
+++ b/client/login/login.js
@@ -1,6 +1,6 @@
 // ── Redirect if already logged in ─────────────────────
 if (AuthService.isLoggedIn()) {
-  window.location.href = "/opportunities/index.html";
+  window.location.href = "/opportunities/";
 }
 
 // ── Mount components ───────────────────────────────────
@@ -45,7 +45,7 @@ document.getElementById("login-form").addEventListener("submit", async (e) => {
 
   try {
     await AuthService.login(email, password);
-    window.location.href = "/opportunities/index.html";
+    window.location.href = "/opportunities/";
   } catch (err) {
     errorEl.textContent = err.message || "Login failed. Please try again.";
     errorEl.hidden = false;

--- a/client/login/login.js
+++ b/client/login/login.js
@@ -1,9 +1,13 @@
-// ── Redirect if already logged in ─────────────────────
+import AuthService from "/shared/services/auth.service.js";
+import Button from "/shared/components/button/button.js";
+import Input from "/shared/components/input/input.js";
+import "/shared/components/nav/nav.js";
+import "/shared/components/footer/footer.js";
+
 if (AuthService.isLoggedIn()) {
   window.location.href = "/opportunities/";
 }
 
-// ── Mount components ───────────────────────────────────
 document.getElementById("email-field").appendChild(
   Input.create({
     type: "email",
@@ -31,7 +35,6 @@ document.getElementById("submit-btn").appendChild(
   }),
 );
 
-// ── Handle submit ──────────────────────────────────────
 document.getElementById("login-form").addEventListener("submit", async (e) => {
   e.preventDefault();
 
@@ -39,7 +42,6 @@ document.getElementById("login-form").addEventListener("submit", async (e) => {
   const password = e.target.querySelector('[name="password"]').value;
   const errorEl = document.getElementById("login-error");
 
-  // Reset error state before each attempt
   errorEl.hidden = true;
   errorEl.textContent = "";
 

--- a/client/opportunities/index.html
+++ b/client/opportunities/index.html
@@ -36,12 +36,13 @@
     </main>
 
     <footer id="footer-root" class="footer"></footer>
+    <script src="/shared/services/api.js"></script>
+    <script src="/shared/services/auth.service.js"></script>
     <script src="/shared/components/button/button.js"></script>
     <script src="/shared/components/dropdown/dropdown.js"></script>
     <script src="/shared/components/search-bar/search-bar.js"></script>
     <script src="/shared/components/nav/nav.js"></script>
     <script src="/shared/components/footer/footer.js"></script>
-    <script src="/shared/services/api.js"></script>
     <script src="opportunities.js"></script>
   </body>
 </html>

--- a/client/opportunities/index.html
+++ b/client/opportunities/index.html
@@ -36,13 +36,6 @@
     </main>
 
     <footer id="footer-root" class="footer"></footer>
-    <script src="/shared/services/api.js"></script>
-    <script src="/shared/services/auth.service.js"></script>
-    <script src="/shared/components/button/button.js"></script>
-    <script src="/shared/components/dropdown/dropdown.js"></script>
-    <script src="/shared/components/search-bar/search-bar.js"></script>
-    <script src="/shared/components/nav/nav.js"></script>
-    <script src="/shared/components/footer/footer.js"></script>
-    <script src="opportunities.js"></script>
+    <script type="module" src="opportunities.js"></script>
   </body>
 </html>

--- a/client/opportunities/opportunities.js
+++ b/client/opportunities/opportunities.js
@@ -1,3 +1,9 @@
+import api from "/shared/services/api.js";
+import Dropdown from "/shared/components/dropdown/dropdown.js";
+import SearchBar from "/shared/components/search-bar/search-bar.js";
+import "/shared/components/nav/nav.js";
+import "/shared/components/footer/footer.js";
+
 const previewDropdown = document.getElementById("preview-dropdown");
 const previewSearchbar = document.getElementById("preview-searchbar");
 const totalOpportunities = document.querySelector(".total");
@@ -37,9 +43,7 @@ function closingSoon(dateStr, status) {
   status = (status ?? "").replace(/_/g, " ");
   if (!dateStr) return status;
   const diff = Math.ceil((new Date(dateStr) - Date.now()) / 86_400_000);
-  if (diff <= 10) {
-    status = "closing soon";
-  }
+  if (diff <= 10) status = "closing soon";
   return status;
 }
 
@@ -47,19 +51,17 @@ function populateOpportunities(opps) {
   listHead.innerHTML = `<p>amount</p> <p>deadline</p>`;
   opportunityCard.innerHTML = opps
     .map(
-      (opp) =>
-        `
+      (opp) => `
      <div class="opportunity-card">
       <div class="opportunity-amount">
         <p class="foundation-amount">${formatAmount(opp.amount_min, opp.amount_max, opp.currency)}</p>
         <p class="foundation-type">${(opp.opportunity_type ?? "").replace(/_/g, " ")}</p>
       </div>
-
       <div class="opportunity-title">
-      <div class="opportunity-title-tag">
-        <p>${opp.opportunity_title}</p>
-        <span class='badge badge--${opp.status}'>${closingSoon(opp.application_deadline, opp.status)}</span>
-      </div>
+        <div class="opportunity-title-tag">
+          <p>${opp.opportunity_title}</p>
+          <span class='badge badge--${opp.status}'>${closingSoon(opp.application_deadline, opp.status)}</span>
+        </div>
         <p class="foundaton-owner">${opp.funder_name}</p>
       </div>
       <div class="opportunity-deadline">

--- a/client/resources/index.html
+++ b/client/resources/index.html
@@ -24,13 +24,6 @@
     </main>
 
     <footer id="footer-root" class="footer"></footer>
-    <script src="/shared/services/api.js"></script>
-    <script src="/shared/services/auth.service.js"></script>
-    <script src="/shared/components/button/button.js"></script>
-    <script src="/shared/components/dropdown/dropdown.js"></script>
-    <script src="/shared/components/search-bar/search-bar.js"></script>
-    <script src="/shared/components/nav/nav.js"></script>
-    <script src="/shared/components/footer/footer.js"></script>
-    <script src="resources.js"></script>
+    <script type="module" src="resources.js"></script>
   </body>
 </html>

--- a/client/resources/index.html
+++ b/client/resources/index.html
@@ -24,6 +24,8 @@
     </main>
 
     <footer id="footer-root" class="footer"></footer>
+    <script src="/shared/services/api.js"></script>
+    <script src="/shared/services/auth.service.js"></script>
     <script src="/shared/components/button/button.js"></script>
     <script src="/shared/components/dropdown/dropdown.js"></script>
     <script src="/shared/components/search-bar/search-bar.js"></script>

--- a/client/resources/resources.js
+++ b/client/resources/resources.js
@@ -1,3 +1,8 @@
+import Dropdown from "/shared/components/dropdown/dropdown.js";
+import SearchBar from "/shared/components/search-bar/search-bar.js";
+import "/shared/components/nav/nav.js";
+import "/shared/components/footer/footer.js";
+
 document.getElementById("preview-dropdown").appendChild(
   Dropdown.create({
     label: "Business sector",

--- a/client/shared/components/button/button.js
+++ b/client/shared/components/button/button.js
@@ -86,3 +86,5 @@ class Button {
     return el;
   }
 }
+
+export default Button;

--- a/client/shared/components/dropdown/dropdown.js
+++ b/client/shared/components/dropdown/dropdown.js
@@ -148,3 +148,5 @@ class Dropdown {
     return wrapper;
   }
 }
+
+export default Dropdown;

--- a/client/shared/components/footer/footer.js
+++ b/client/shared/components/footer/footer.js
@@ -114,3 +114,5 @@ class FooterComponent {
 }
 
 new FooterComponent().mount("#footer-root");
+
+export default FooterComponent;

--- a/client/shared/components/input/input.js
+++ b/client/shared/components/input/input.js
@@ -127,3 +127,5 @@ class Input {
     return wrapper;
   }
 }
+
+export default Input;

--- a/client/shared/components/nav/nav.css
+++ b/client/shared/components/nav/nav.css
@@ -102,6 +102,70 @@
   display: none;
 }
 
+/* ── Avatar ── */
+.nav__avatar-wrapper {
+  position: relative;
+}
+
+.nav__avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-full);
+  background-color: var(--color-purple-100, #ede9fe);
+  color: var(--color-purple-800);
+  border: 2px solid var(--color-purple-200, #ddd6fe);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.nav__avatar:hover {
+  background-color: var(--color-purple-200, #ddd6fe);
+  border-color: var(--color-primary);
+}
+
+.nav__avatar-menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  right: 0;
+  min-width: 140px;
+  background-color: var(--color-bg-base);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: 200;
+  overflow: hidden;
+}
+
+.nav__avatar-menu--open {
+  display: block;
+}
+
+.nav__avatar-menu-item {
+  display: block;
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  background: none;
+  border: none;
+  text-align: left;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.nav__avatar-menu-item:hover {
+  background-color: var(--color-surface-hover, #f5f3ff);
+}
+
 /* ── Responsive ── */
 @media (max-width: 768px) {
   .nav {

--- a/client/shared/components/nav/nav.css
+++ b/client/shared/components/nav/nav.css
@@ -111,9 +111,9 @@
   width: 40px;
   height: 40px;
   border-radius: var(--radius-full);
-  background-color: var(--color-purple-100, #ede9fe);
+  background-color: var(--color-purple-50);
   color: var(--color-purple-800);
-  border: 2px solid var(--color-purple-200, #ddd6fe);
+  border: 2px solid var(--color-purple-200);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -125,7 +125,7 @@
 }
 
 .nav__avatar:hover {
-  background-color: var(--color-purple-200, #ddd6fe);
+  background-color: var(--color-purple-100);
   border-color: var(--color-primary);
 }
 
@@ -134,13 +134,14 @@
   position: absolute;
   top: calc(100% + var(--space-2));
   right: 0;
+  z-index: 200;
+  overflow: hidden;
+
   min-width: 140px;
   background-color: var(--color-bg-base);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
-  z-index: 200;
-  overflow: hidden;
 }
 
 .nav__avatar-menu--open {
@@ -163,7 +164,7 @@
 }
 
 .nav__avatar-menu-item:hover {
-  background-color: var(--color-surface-hover, #f5f3ff);
+  background-color: var(--color-neutral-50);
 }
 
 /* ── Responsive ── */

--- a/client/shared/components/nav/nav.js
+++ b/client/shared/components/nav/nav.js
@@ -1,3 +1,6 @@
+import AuthService from "/shared/services/auth.service.js";
+import Button from "/shared/components/button/button.js";
+
 const USER_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
   <path d="M12 12c2.761 0 5-2.239 5-5s-2.239-5-5-5-5 2.239-5 5 2.239 5 5 5zm0 2c-3.33 0-10 1.672-10 5v1h20v-1c0-3.328-6.67-5-10-5z"/>
 </svg>`;
@@ -22,17 +25,11 @@ const NAV_CONFIG = {
 
 class NavComponent {
   #isLoggedIn() {
-    return Boolean(AuthService.isLoggedIn());
+    return AuthService.isLoggedIn();
   }
 
   #logout() {
-    if (AuthService) {
-      AuthService.logout();
-    } else {
-      localStorage.removeItem("ekehi_access_token");
-      localStorage.removeItem("ekehi_refresh_token");
-      window.location.href = "/login/";
-    }
+    AuthService.logout();
   }
 
   #isActive(href) {

--- a/client/shared/components/nav/nav.js
+++ b/client/shared/components/nav/nav.js
@@ -1,3 +1,7 @@
+const USER_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+  <path d="M12 12c2.761 0 5-2.239 5-5s-2.239-5-5-5-5 2.239-5 5 2.239 5 5 5zm0 2c-3.33 0-10 1.672-10 5v1h20v-1c0-3.328-6.67-5-10-5z"/>
+</svg>`;
+
 const NAV_CONFIG = {
   logo: {
     href: "/",
@@ -43,6 +47,55 @@ class NavComponent {
     return anchor;
   }
 
+  #buildAvatar() {
+    const wrapper = document.createElement("div");
+    wrapper.className = "nav__avatar-wrapper";
+
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "nav__avatar";
+    btn.setAttribute("aria-label", "Account menu");
+    btn.setAttribute("aria-expanded", "false");
+    btn.setAttribute("aria-haspopup", "menu");
+    btn.innerHTML = USER_ICON_SVG;
+
+    const menu = document.createElement("div");
+    menu.className = "nav__avatar-menu";
+    menu.setAttribute("role", "menu");
+
+    const logoutBtn = document.createElement("button");
+    logoutBtn.type = "button";
+    logoutBtn.className = "nav__avatar-menu-item";
+    logoutBtn.setAttribute("role", "menuitem");
+    logoutBtn.textContent = "Log out";
+    logoutBtn.addEventListener("click", () => window.AuthService?.logout());
+
+    menu.appendChild(logoutBtn);
+
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const isOpen = menu.classList.contains("nav__avatar-menu--open");
+      menu.classList.toggle("nav__avatar-menu--open", !isOpen);
+      btn.setAttribute("aria-expanded", String(!isOpen));
+    });
+
+    document.addEventListener("click", () => {
+      menu.classList.remove("nav__avatar-menu--open");
+      btn.setAttribute("aria-expanded", "false");
+    });
+
+    wrapper.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        menu.classList.remove("nav__avatar-menu--open");
+        btn.setAttribute("aria-expanded", "false");
+        btn.focus();
+      }
+    });
+
+    wrapper.append(btn, menu);
+    return wrapper;
+  }
+
   #buildNavLinks(links, cta) {
     const ul = document.createElement("ul");
     ul.className = "nav__links";
@@ -70,24 +123,35 @@ class NavComponent {
     ctaMobile.className = "nav__cta-mobile";
     ctaMobile.setAttribute("aria-label", "Account actions");
 
-    ctaMobile.appendChild(
-      Button.create({
-        label: cta.signup.label,
-        variant: "primary",
-        size: "sm",
-        as: "a",
-        href: cta.signup.href,
-      }),
-    );
-    ctaMobile.appendChild(
-      Button.create({
-        label: cta.login.label,
-        variant: "outline",
-        size: "sm",
-        as: "a",
-        href: cta.login.href,
-      }),
-    );
+    if (window.AuthService?.isLoggedIn()) {
+      ctaMobile.appendChild(
+        Button.create({
+          label: "Log out",
+          variant: "outline",
+          size: "sm",
+          onClick: () => window.AuthService?.logout(),
+        }),
+      );
+    } else {
+      ctaMobile.appendChild(
+        Button.create({
+          label: cta.signup.label,
+          variant: "primary",
+          size: "sm",
+          as: "a",
+          href: cta.signup.href,
+        }),
+      );
+      ctaMobile.appendChild(
+        Button.create({
+          label: cta.login.label,
+          variant: "outline",
+          size: "sm",
+          as: "a",
+          href: cta.login.href,
+        }),
+      );
+    }
 
     ctaLi.appendChild(ctaMobile);
     ul.appendChild(ctaLi);
@@ -99,6 +163,11 @@ class NavComponent {
     const wrapper = document.createElement("div");
     wrapper.className = "nav__cta";
     wrapper.setAttribute("aria-label", "Account actions");
+
+    if (window.AuthService?.isLoggedIn()) {
+      wrapper.appendChild(this.#buildAvatar());
+      return wrapper;
+    }
 
     wrapper.appendChild(
       Button.create({

--- a/client/shared/components/nav/nav.js
+++ b/client/shared/components/nav/nav.js
@@ -21,6 +21,20 @@ const NAV_CONFIG = {
 };
 
 class NavComponent {
+  #isLoggedIn() {
+    return Boolean(AuthService.isLoggedIn());
+  }
+
+  #logout() {
+    if (AuthService) {
+      AuthService.logout();
+    } else {
+      localStorage.removeItem("ekehi_access_token");
+      localStorage.removeItem("ekehi_refresh_token");
+      window.location.href = "/login/";
+    }
+  }
+
   #isActive(href) {
     const pathname = window.location.pathname;
     if (href === "/") return pathname === "/";
@@ -68,7 +82,7 @@ class NavComponent {
     logoutBtn.className = "nav__avatar-menu-item";
     logoutBtn.setAttribute("role", "menuitem");
     logoutBtn.textContent = "Log out";
-    logoutBtn.addEventListener("click", () => window.AuthService?.logout());
+    logoutBtn.addEventListener("click", () => this.#logout());
 
     menu.appendChild(logoutBtn);
 
@@ -123,13 +137,13 @@ class NavComponent {
     ctaMobile.className = "nav__cta-mobile";
     ctaMobile.setAttribute("aria-label", "Account actions");
 
-    if (window.AuthService?.isLoggedIn()) {
+    if (this.#isLoggedIn()) {
       ctaMobile.appendChild(
         Button.create({
           label: "Log out",
           variant: "outline",
           size: "sm",
-          onClick: () => window.AuthService?.logout(),
+          onClick: () => this.#logout(),
         }),
       );
     } else {
@@ -164,7 +178,7 @@ class NavComponent {
     wrapper.className = "nav__cta";
     wrapper.setAttribute("aria-label", "Account actions");
 
-    if (window.AuthService?.isLoggedIn()) {
+    if (this.#isLoggedIn()) {
       wrapper.appendChild(this.#buildAvatar());
       return wrapper;
     }

--- a/client/shared/components/search-bar/search-bar.js
+++ b/client/shared/components/search-bar/search-bar.js
@@ -70,3 +70,5 @@ class SearchBar {
     return wrapper;
   }
 }
+
+export default SearchBar;

--- a/client/shared/constants/enums.js
+++ b/client/shared/constants/enums.js
@@ -71,6 +71,4 @@ const EKEHI_ENUMS = {
   },
 };
 
-if (typeof window !== "undefined") {
-  window.EKEHI_ENUMS = EKEHI_ENUMS;
-}
+export default EKEHI_ENUMS;

--- a/client/shared/services/api.js
+++ b/client/shared/services/api.js
@@ -1,27 +1,5 @@
-/**
- * api.js — Base fetch wrapper for the Ekehi API.
- *
- * Usage:
- *   const data = await api.get('/opportunities?page=1');
- *   const data = await api.post('/auth/login', { email, password });
- *
- * Script loading order (in HTML):
- *   <script src="/shared/services/api.js"></script>
- *   <script src="/shared/services/auth.service.js"></script>  <!-- if auth needed -->
- *   <script src="page.js"></script>
- */
+const BASE_URL = "https://api-ekehi-dev.onrender.com/api/v1";
 
-const BASE_URL =
-  (typeof window !== "undefined" && window.EKEHI_API_URL) ||
-  "https://api-ekehi-dev.onrender.com/api/v1";
-
-/**
- * Core request function.
- * @param {string} path     - API path relative to BASE_URL (e.g. '/opportunities')
- * @param {RequestInit} options - fetch options
- * @returns {Promise<object>} - Parsed JSON body ({ success, message, data, meta? })
- * @throws {Error} with message from server on non-2xx responses
- */
 async function request(path, options = {}) {
   const token = localStorage.getItem("ekehi_access_token");
 
@@ -32,11 +10,9 @@ async function request(path, options = {}) {
   };
 
   const response = await fetch(`${BASE_URL}${path}`, { ...options, headers });
-
   const body = await response.json().catch(() => ({}));
 
   if (response.status === 401) {
-    // Clear stale tokens and redirect to login
     localStorage.removeItem("ekehi_access_token");
     localStorage.removeItem("ekehi_refresh_token");
     window.location.href = "/login/";
@@ -64,9 +40,4 @@ const api = {
   delete: (path) => request(path, { method: "DELETE" }),
 };
 
-// Export for use in both browser and (if needed) module environments
-if (typeof module !== "undefined" && module.exports) {
-  module.exports = api;
-} else {
-  window.api = api;
-}
+export default api;

--- a/client/shared/services/api.js
+++ b/client/shared/services/api.js
@@ -39,7 +39,7 @@ async function request(path, options = {}) {
     // Clear stale tokens and redirect to login
     localStorage.removeItem("ekehi_access_token");
     localStorage.removeItem("ekehi_refresh_token");
-    window.location.href = "/login/index.html";
+    window.location.href = "/login/";
     return;
   }
 

--- a/client/shared/services/auth.service.js
+++ b/client/shared/services/auth.service.js
@@ -1,26 +1,9 @@
-/**
- * auth.service.js — Authentication helpers for the Ekehi frontend.
- *
- * Depends on: api.js (must be loaded first)
- *
- * Usage:
- *   await AuthService.login('user@example.com', 'password');
- *   AuthService.isLoggedIn();   // → true | false
- *   AuthService.logout();
- */
+import api from "/shared/services/api.js";
 
 const TOKEN_KEY = "ekehi_access_token";
 const REFRESH_KEY = "ekehi_refresh_token";
 
 const AuthService = {
-  /**
-   * Sign up a new user.
-   * @param {string} email
-   * @param {string} password
-   * @param {string} firstName
-   * @param {string} lastName
-   * @returns {Promise<object>} server response body
-   */
   async signup(email, password, firstName, lastName) {
     const body = await api.post("/auth/signup", {
       email,
@@ -34,12 +17,6 @@ const AuthService = {
     return body;
   },
 
-  /**
-   * Log in with email + password. Stores tokens in localStorage.
-   * @param {string} email
-   * @param {string} password
-   * @returns {Promise<object>} server response body
-   */
   async login(email, password) {
     const body = await api.post("/auth/login", { email, password });
     if (body.data) {
@@ -49,9 +26,6 @@ const AuthService = {
     return body;
   },
 
-  /**
-   * Log out the current user. Clears local storage.
-   */
   async logout() {
     try {
       await api.post("/auth/logout", {});
@@ -64,33 +38,19 @@ const AuthService = {
     }
   },
 
-  /**
-   * Check if a user is currently logged in (token present in localStorage).
-   * @returns {boolean}
-   */
   isLoggedIn() {
     return Boolean(localStorage.getItem(TOKEN_KEY));
   },
 
-  /**
-   * Get the stored access token.
-   * @returns {string|null}
-   */
   getToken() {
     return localStorage.getItem(TOKEN_KEY);
   },
 
   /** @private */
   _storeSession(session) {
-    if (session?.access_token)
-      localStorage.setItem(TOKEN_KEY, session.access_token);
-    if (session?.refresh_token)
-      localStorage.setItem(REFRESH_KEY, session.refresh_token);
+    if (session?.access_token) localStorage.setItem(TOKEN_KEY, session.access_token);
+    if (session?.refresh_token) localStorage.setItem(REFRESH_KEY, session.refresh_token);
   },
 };
 
-if (typeof module !== "undefined" && module.exports) {
-  module.exports = AuthService;
-} else {
-  window.AuthService = AuthService;
-}
+export default AuthService;

--- a/client/shared/services/auth.service.js
+++ b/client/shared/services/auth.service.js
@@ -60,7 +60,7 @@ const AuthService = {
     } finally {
       localStorage.removeItem(TOKEN_KEY);
       localStorage.removeItem(REFRESH_KEY);
-      window.location.href = "/login/index.html";
+      window.location.href = "/login/";
     }
   },
 

--- a/client/signup/index.html
+++ b/client/signup/index.html
@@ -26,10 +26,6 @@
 
     <footer id="footer-root" class="footer"></footer>
 
-    <script src="/shared/components/button/button.js"></script>
-    <script src="/shared/components/input/input.js"></script>
-    <script src="/shared/components/nav/nav.js"></script>
-    <script src="/shared/components/footer/footer.js"></script>
-    <script src="signup.js"></script>
+    <script type="module" src="signup.js"></script>
   </body>
 </html>

--- a/client/signup/signup.js
+++ b/client/signup/signup.js
@@ -1,3 +1,8 @@
+import Button from "/shared/components/button/button.js";
+import Input from "/shared/components/input/input.js";
+import "/shared/components/nav/nav.js";
+import "/shared/components/footer/footer.js";
+
 document
   .getElementById("preview-input")
   .appendChild(Input.create({ placeholder: "Email address", type: "email" }));

--- a/docs/setup/es-modules-migration.md
+++ b/docs/setup/es-modules-migration.md
@@ -1,0 +1,62 @@
+# ES Modules Migration Plan
+
+## Goal
+Convert all client-side JS from globals + ordered `<script>` tags to native ES modules (`import`/`export`). This removes the need to repeat `api.js` and `auth.service.js` on every page and eliminates implicit ordering requirements.
+
+## Dependency Graph (after migration)
+
+```
+api.js
+  └── auth.service.js
+        └── nav.js (also imports button.js)
+
+button.js       ← standalone
+input.js        ← standalone
+dropdown.js     ← standalone
+search-bar.js   ← standalone
+footer.js       ← standalone
+enums.js        ← standalone
+
+Page scripts import only what they use
+```
+
+## Changes Per File
+
+### Shared services
+| File | Change |
+|------|--------|
+| `api.js` | Remove CJS compat block → `export default api` |
+| `auth.service.js` | `import api` → Remove CJS compat block → `export default AuthService` |
+
+### Shared components
+| File | Change |
+|------|--------|
+| `button.js` | `export default Button` |
+| `input.js` | `export default Input` |
+| `dropdown.js` | `export default Dropdown` |
+| `search-bar.js` | `export default SearchBar` |
+| `nav.js` | `import Button, AuthService` → use them directly → auto-mounts on import |
+| `footer.js` | No imports needed → auto-mounts on import |
+| `enums.js` | Remove `window.EKEHI_ENUMS` → `export default EKEHI_ENUMS` |
+
+### Page scripts (add imports, remove global references)
+| File | Imports |
+|------|---------|
+| `landing/landing.js` | `Button`, nav, footer |
+| `login/login.js` | `AuthService`, `Button`, `Input`, nav, footer |
+| `signup/signup.js` | `Button`, `Input`, nav, footer |
+| `opportunities/opportunities.js` | `api`, `Dropdown`, `SearchBar`, nav, footer |
+| `resources/resources.js` | `Dropdown`, `SearchBar`, nav, footer |
+| `contributors/contributors.js` | nav, footer |
+
+### HTML pages
+Each page goes from many `<script>` tags to one:
+```html
+<script type="module" src="./page.js"></script>
+```
+`type="module"` is automatically deferred — no load-order issues.
+
+## Notes
+- ES modules are cached — `auth.service.js` imported by both `nav.js` and `login.js` evaluates only once.
+- Auto-mounting in `nav.js` / `footer.js` runs as a side effect when the module is imported — no change needed in page scripts.
+- `type="module"` scripts run after the DOM is parsed — `DOMContentLoaded` wrappers become unnecessary but harmless.


### PR DESCRIPTION
## Summary
Converted all client-side JS from globals + ordered `<script>` tags to native ES modules (`import`/`export`). Each HTML page now has a single `<script type="module">` entry point.

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [x] Chore / refactor

## Linked Issue
Closes #73

## ClickUp Task (if applicable)
Link:

## Changes Made
- `api.js` and `auth.service.js` use `export default` — `auth.service.js` imports `api` directly
- All shared components (`button`, `input`, `dropdown`, `search-bar`, `nav`, `footer`) use `export default`
- `enums.js` uses `export default` instead of `window.EKEHI_ENUMS`
- `nav.js` imports `AuthService` and `Button` directly — no `window.*` fallbacks needed
- All page scripts import their own dependencies explicitly
- All HTML pages reduced to a single `<script type="module" src="page.js">` tag
- Removed all `window.X = X` global assignments and CJS `module.exports` compat blocks

## Screenshots (for UI changes)
N/A — refactor only, no visual changes.

## Checklist
- [x] Branch is up to date with `development`
- [x] Code follows project conventions
- [x] No `.env` or secrets committed
- [x] UI changes tested on mobile and desktop
- [ ] Backend changes tested locally
- [x] PR is linked to an issue or ClickUp task