### PR TITLE
[backend] fix: use separate anon-key client for auth to prevent singleton contamination

### DIFF
--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -2,6 +2,7 @@ require("dotenv").config();
 
 const requiredVars = [
   "SUPABASE_URL",
+  "SUPABASE_ANON_KEY",
   "SUPABASE_SERVICE_ROLE_KEY",
   "JWT_SECRET",
 ];

--- a/server/src/services/auth.service.js
+++ b/server/src/services/auth.service.js
@@ -1,7 +1,18 @@
+const { createClient } = require("@supabase/supabase-js");
 const supabase = require("../config/supabaseClient");
+const { supabaseUrl, supabaseAnonKey } = require("../config/env");
+
+// Separate client for user-facing auth operations (anon key).
+// Must NOT be the service role singleton — signInWithPassword sets an in-memory
+// session on the client, which would contaminate the singleton and cause all
+// subsequent DB queries to use the user JWT instead of the service role key,
+// making RLS apply and returning empty results on public endpoints.
+const authClient = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
 
 const signUp = async ({ email, password, firstName, lastName }) => {
-  const { data, error } = await supabase.auth.signUp({
+  const { data, error } = await authClient.auth.signUp({
     email,
     password,
     options: {
@@ -11,7 +22,7 @@ const signUp = async ({ email, password, firstName, lastName }) => {
 
   if (error) throw error;
 
-  // Best-effort profile creation — auth user is already created above
+  // Best-effort profile creation via service role client (bypasses RLS)
   if (data.user) {
     const { error: profileError } = await supabase.from("profiles").insert({
       id: data.user.id,
@@ -32,7 +43,7 @@ const signUp = async ({ email, password, firstName, lastName }) => {
 };
 
 const signIn = async ({ email, password }) => {
-  const { data, error } = await supabase.auth.signInWithPassword({
+  const { data, error } = await authClient.auth.signInWithPassword({
     email,
     password,
   });
@@ -41,7 +52,7 @@ const signIn = async ({ email, password }) => {
 };
 
 const signOut = async (accessToken) => {
-  // Use user's own client context to invalidate their session
+  // Use admin API on the service role client to invalidate the session
   const { error } = await supabase.auth.admin.signOut(accessToken);
   if (error) throw error;
 };


### PR DESCRIPTION
## Summary
`signInWithPassword` was being called on the shared service role Supabase singleton. Even with `persistSession: false`, GoTrueClient stores the returned user JWT in-memory as `currentSession`. All subsequent DB queries then send `Authorization: Bearer <user_jwt>`, which makes PostgREST apply RLS — returning empty results on public endpoints after any login.

Fix: introduce a dedicated `authClient` (anon key) for `signIn`/`signUp` so the service role singleton is never contaminated.

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Linked Issue
Closes #76

## ClickUp Task (if applicable)
Link:

## Changes Made
- `server/src/services/auth.service.js` — create a separate `authClient` (anon key, `persistSession: false`) used exclusively for `signIn` and `signUp`; service role singleton now only used for DB ops and admin calls
- `server/src/config/env.js` — add `SUPABASE_ANON_KEY` to `requiredVars` since it is now a hard dependency

## Screenshots (for UI changes)
N/A — backend only

## Checklist
- [x] Branch is up to date with `development`
- [x] Code follows project conventions
- [x] No `.env` or secrets committed
- [ ] UI changes tested on mobile and desktop
- [x] Backend changes tested locally
- [x] PR is linked to an issue or ClickUp task