### PR TITLE
[frontend] feat: build filter section of opportunities page

### DIFF
--- a/client/opportunities/index.html
+++ b/client/opportunities/index.html
@@ -19,8 +19,23 @@
     </header>
 
     <main class="container">
-      <div id="preview-searchbar"></div>
-      <div id="preview-dropdown"></div>
+      <!-- Page header -->
+      <section class="page-header text-center">
+        <h1 class="">Funding Opportunities</h1>
+        <p>
+          Explore various funding options available to support your projects and
+          initiatives.
+        </p>
+      </section>
+
+      <!-- Search + filters -->
+      <section class="opportunities__filters">
+        <div class="opportunities__search">
+          <div id="search-bar"></div>
+        </div>
+
+        <div class="opportunities__dropdowns flex" id="filter-dropdowns"></div>
+      </section>
 
       <!-- Opportunities List -->
       <section id="opportunity-list-display" aria-label="opportunities">

--- a/client/opportunities/opportunities.css
+++ b/client/opportunities/opportunities.css
@@ -1,3 +1,33 @@
+/* filter section styling */
+.page-header {
+  margin-bottom: var(--space-10);
+}
+
+.opportunities__filters {
+  width: 100%;
+}
+
+.opportunities__search {
+  margin-bottom: var(--space-4);
+}
+
+.opportunities__dropdowns {
+  width: 88%;
+  gap: var(--space-2);
+}
+
+.opportunities__dropdowns .dropdown-wrapper {
+  flex: 1;
+  display: flex;
+}
+
+.opportunities__dropdowns .dropdown__trigger {
+  width: 100%;
+  font-weight: var(--font-regular);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+}
+
 #opportunity-list-display {
   padding-top: var(--space-16);
   text-transform: capitalize;

--- a/client/opportunities/opportunities.js
+++ b/client/opportunities/opportunities.js
@@ -1,3 +1,9 @@
+import api from "/shared/services/api.js";
+import Dropdown from "/shared/components/dropdown/dropdown.js";
+import SearchBar from "/shared/components/search-bar/search-bar.js";
+import "/shared/components/nav/nav.js";
+import "/shared/components/footer/footer.js";
+
 const searchBar = document.getElementById("search-bar");
 const filterContainer = document.getElementById("filter-dropdowns");
 const totalOpportunities = document.querySelector(".total");

--- a/client/opportunities/opportunities.js
+++ b/client/opportunities/opportunities.js
@@ -1,22 +1,113 @@
-const previewDropdown = document.getElementById("preview-dropdown");
-const previewSearchbar = document.getElementById("preview-searchbar");
+const searchBar = document.getElementById("search-bar");
+const filterContainer = document.getElementById("filter-dropdowns");
 const totalOpportunities = document.querySelector(".total");
 const listHead = document.querySelector(".list-head");
 const opportunityCard = document.querySelector(".opportunityCard");
 
-previewDropdown.appendChild(
-  Dropdown.create({
-    label: "Business sector",
-    options: [
-      { value: "fintech", label: "Fintech" },
-      { value: "health", label: "Health & Wellness" },
-      { value: "retail", label: "Retail" },
-    ],
+// 1. Filter state object — single source of truth
+const filters = {
+  sector: null,
+  status: null,
+  stage: null,
+  country: null,
+  opportunity_type: null,
+  search: null,
+};
+
+function onFilterChange(key, value) {
+  filters[key] = value || null;
+  console.log("[Opportunities] active filters:", filters);
+}
+
+// 2. Search bar
+searchBar.appendChild(
+  SearchBar.create({
+    placeholder: "Search 30+ funding opportunities",
+    onSearch: (query) => onFilterChange("search", query),
   }),
 );
 
-previewSearchbar.appendChild(
-  SearchBar.create({ placeholder: "Search 30+ funding opportunities" }),
+// 3. Filter dropdowns
+
+filterContainer.appendChild(
+  Dropdown.create({
+    label: "Sector",
+    name: "sector",
+    options: [
+      { value: "agriculture_food", label: "Agriculture & Food Processing" },
+      { value: "beauty_personal_care", label: "Beauty & Personal Care" },
+      { value: "creative_industries", label: "Creative Industries" },
+      { value: "education_edtech", label: "Education & EdTech" },
+      { value: "fashion_textiles", label: "Fashion & Textiles" },
+      {
+        value: "financial_services_fintech",
+        label: "Financial Services & Fintech",
+      },
+      { value: "health_wellness", label: "Health & Wellness" },
+      { value: "logistics_distribution", label: "Logistics & Distribution" },
+      { value: "retail_ecommerce", label: "Retail & E-Commerce" },
+      { value: "technology_digital", label: "Technology & Digital Services" },
+    ],
+    onChange: (value) => onFilterChange("sector", value),
+  }),
+);
+
+filterContainer.appendChild(
+  Dropdown.create({
+    label: "Status",
+    name: "status",
+    options: [
+      { value: "open", label: "Open" },
+      { value: "rolling_applications", label: "Rolling Applications" },
+      { value: "closed", label: "Closed" },
+    ],
+    onChange: (value) => onFilterChange("status", value),
+  }),
+);
+
+filterContainer.appendChild(
+  Dropdown.create({
+    label: "Business stage",
+    name: "stage",
+    options: [
+      { value: "idea", label: "Idea" },
+      { value: "early", label: "Early" },
+      { value: "growth", label: "Growth" },
+    ],
+    onChange: (value) => onFilterChange("stage", value),
+  }),
+);
+
+filterContainer.appendChild(
+  Dropdown.create({
+    label: "Region",
+    name: "country",
+    options: [
+      { value: "Nigeria", label: "Nigeria" },
+      { value: "Ghana", label: "Ghana" },
+      { value: "Kenya", label: "Kenya" },
+      { value: "South Africa", label: "South Africa" },
+    ],
+    onChange: (value) => onFilterChange("country", value),
+  }),
+);
+
+filterContainer.appendChild(
+  Dropdown.create({
+    label: "Type",
+    name: "opportunity_type",
+    options: [
+      { value: "grant_ngo", label: "Grant (NGO)" },
+      { value: "grant_government", label: "Grant (Government)" },
+      { value: "angel_investment", label: "Angel Investment" },
+      { value: "accelerator", label: "Accelerator" },
+      { value: "loan", label: "Loan" },
+      { value: "microfinance", label: "Microfinance" },
+      { value: "vc", label: "VC" },
+      { value: "prize_money", label: "Prize Money" },
+    ],
+    onChange: (value) => onFilterChange("opportunity_type", value),
+  }),
 );
 
 function formatAmount(min, max, currency) {


### PR DESCRIPTION
## Summary
<!-- Describe what this PR does and why -->
Builds the filter section of the Opportunities page. This includes the hero header, search bar, and five filter dropdowns (Sector, Status, Business stage, Region, Type).

## Why
Implements the UI wiring for the filter section as described 
in the issue. All filter and search interactions currently log 
the active filter state to the console. No API re-fetching 
is included — that is a separate issue.

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Linked Issue
Closes #58 

## ClickUp Task (if applicable)
Link:

## Changes Made
<!-- List key changes -->
- Added hero header with title and subtitle
- Implemented search bar using the SearchBar component
- Implemented five filter dropdowns using the Dropdown component
- Added filter state object as single source of truth
- Added onFilterChange function that logs active filters to console
- Styled filter section to match Figma design

## Screenshots (for UI changes)
<img width="1909" height="438" alt="Screenshot 2026-03-13 151539" src="https://github.com/user-attachments/assets/b0d6ad3f-b74d-448f-b039-3d73d794582f" />


## Checklist
- [ ] Branch is up to date with `development`
- [ ] Code follows project conventions
- [ ] No `.env` or secrets committed
- [ ] UI changes tested on mobile and desktop
- [ ] Backend changes tested locally
- [ ] PR is linked to an issue or ClickUp task
