### PR TITLE
[frontend] feat: implement opportunity detail page and wire listing cards

### DIFF
--- a/client/opportunities/detail/detail.css
+++ b/client/opportunities/detail/detail.css
@@ -1,0 +1,201 @@
+.detail-breadcrumb {
+  padding-top: var(--space-10);
+  padding-bottom: var(--space-8);
+  font-size: var(--text-sm);
+}
+
+.back-link {
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: var(--font-medium);
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.ref-code {
+  color: var(--color-neutral-500);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Detail Header Styles */
+.detail-header {
+  padding-bottom: var(--space-8);
+  border-bottom: 1px solid var(--color-neutral-300);
+}
+
+.detail-header__badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+  text-transform: capitalize;
+}
+
+.detail-title {
+  font-family: var(--font-serif);
+  font-size: var(--text-3xl);
+  line-height: var(--leading-tight);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-2);
+}
+
+.detail-funder {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  color: var(--color-neutral-600);
+}
+
+.detail-stats {
+  display: flex;
+  gap: var(--space-0);
+  padding: var(--space-6) 0;
+  border-bottom: 1px solid var(--color-neutral-300);
+}
+
+.detail-stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  flex: 1;
+  padding: var(--space-4) var(--space-6);
+  border-right: 1px solid var(--color-neutral-300);
+}
+
+.detail-stat:first-child {
+  padding-left: 0;
+}
+
+.detail-stat:last-child {
+  border-right: none;
+}
+
+.detail-stat__label {
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-neutral-500);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.detail-stat__value {
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  text-transform: capitalize;
+}
+
+.detail-stat__sub {
+  font-size: var(--text-xs);
+  color: var(--color-neutral-500);
+}
+
+.detail-body {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-6);
+  column-gap: var(--space-16);
+  padding-top: var(--space-10);
+  padding-bottom: var(--space-10);
+}
+
+.detail-section h2 {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  color: var(--color-neutral-600);
+  margin-bottom: var(--space-2);
+}
+
+.detail-section p {
+  font-size: var(--text-base);
+  color: var(--color-neutral-700);
+  white-space: pre-line;
+  text-wrap: pretty;
+}
+
+.detail-tags-row {
+  display: flex;
+  gap: var(--space-8);
+  flex: 1;
+}
+
+.detail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.detail-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-4);
+  padding-top: var(--space-8);
+  padding-bottom: var(--space-16);
+  border-top: 1px solid var(--color-neutral-300);
+}
+
+.apply-btn {
+  padding: var(--space-3) var(--space-8);
+  border-radius: 6px;
+}
+
+.apply-btn:hover {
+  opacity: 0.88;
+}
+
+.no-apply {
+  font-size: var(--text-sm);
+  color: var(--color-neutral-500);
+}
+
+.detail-contact {
+  font-size: var(--text-sm);
+  color: var(--color-neutral-600);
+}
+
+.detail-contact a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.detail-contact a:hover {
+  text-decoration: underline;
+}
+
+.loading {
+  padding-top: var(--space-16);
+  color: var(--color-neutral-500);
+  font-size: var(--text-base);
+}
+
+.error-message {
+  padding-top: var(--space-8);
+  color: #d72525;
+  font-size: var(--text-base);
+}
+
+@media screen and (max-width: 768px) {
+  .detail-title {
+    font-size: var(--text-2xl);
+  }
+
+  .detail-stats {
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .detail-stat {
+    padding: var(--space-3) 0;
+    border-right: none;
+    border-bottom: 1px solid var(--color-neutral-200);
+  }
+
+  .detail-stat:last-child {
+    border-bottom: none;
+  }
+}

--- a/client/opportunities/detail/detail.js
+++ b/client/opportunities/detail/detail.js
@@ -1,0 +1,147 @@
+import api from "/shared/services/api.js";
+import "/shared/components/nav/nav.js";
+import "/shared/components/footer/footer.js";
+import {
+  formatAmount,
+  daysUntil,
+  humanize,
+} from "/shared/utils/opportunity.utils.js";
+
+const root = document.getElementById("detail-root");
+
+function formatDate(date) {
+  if (!date) return "—";
+  return date.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+function tagList(arr) {
+  if (!arr?.length) return "<span>—</span>";
+  return arr
+    .map((t) => `<span class="badge badge--tag">${humanize(t)}</span>`)
+    .join("");
+}
+
+function breadcrumb(refCode = "") {
+  return `
+    <nav class="detail-breadcrumb flex items-center justify-between" aria-label="Breadcrumb">
+      <a href="/opportunities/" class="back-link">← Back to Opportunities</a>
+      ${refCode ? `<span class="ref-code">${refCode}</span>` : ""}
+    </nav>`;
+}
+
+function renderHeader(opp) {
+  return `
+    <header class="detail-header">
+      <div class="detail-header__badges">
+        <span class="badge badge--${opp.status}">${humanize(opp.status)}</span>
+        <span class="badge badge--type">${humanize(opp.opportunity_type)}</span>
+        ${opp.is_women_only ? '<span class="badge badge--flag">Women only</span>' : ""}
+        ${opp.is_equity_free ? '<span class="badge badge--flag">Equity free</span>' : ""}
+      </div>
+      <h1 class="detail-title">${opp.opportunity_title}</h1>
+      <p class="detail-funder">${opp.funder_name}</p>
+    </header>`;
+}
+
+function renderStats(opp, deadlineDate) {
+  const deadlineSub = daysUntil(deadlineDate);
+  return `
+    <section class="detail-stats">
+      <div class="detail-stat">
+        <span class="detail-stat__label">Funding</span>
+        <span class="detail-stat__value">${formatAmount(opp.amount_min, opp.amount_max, opp.currency)}</span>
+      </div>
+      <div class="detail-stat">
+        <span class="detail-stat__label">Deadline</span>
+        <span class="detail-stat__value">${formatDate(deadlineDate)}</span>
+        ${deadlineSub ? `<span class="detail-stat__sub">${deadlineSub}</span>` : ""}
+      </div>
+      <div class="detail-stat">
+        <span class="detail-stat__label">Country</span>
+        <span class="detail-stat__value">${opp.country ?? "—"}</span>
+      </div>
+    </section>`;
+}
+
+function renderBody(opp) {
+  return `
+    <section class="detail-body">
+      <article class="detail-section">
+        <h2>About this opportunity</h2>
+        <p>${opp.description ?? "—"}</p>
+      </article>
+      <article class="detail-section">
+        <h2>Eligibility criteria</h2>
+        <p>${opp.eligibility_criteria ?? "—"}</p>
+      </article>
+      <div class="detail-tags-row">
+        <div class="detail-section">
+          <h2>Sectors</h2>
+          <div class="detail-tags">${tagList(opp.sectors)}</div>
+        </div>
+        <div class="detail-section">
+          <h2>Stages</h2>
+          <div class="detail-tags">${tagList(opp.stages)}</div>
+        </div>
+      </div>
+    </section>`;
+}
+
+function renderActions(opp) {
+  const applyLink = opp.apply_url
+    ? `<a href="${opp.apply_url}" target="_blank" rel="noopener noreferrer" class="btn btn--primary apply-btn">Apply now</a>`
+    : '<p class="no-apply">No application link available.</p>';
+
+  const contactLine = opp.contact_email
+    ? `<p class="detail-contact">Contact: <a href="mailto:${opp.contact_email}">${opp.contact_email}</a></p>`
+    : "";
+
+  return `<div class="detail-actions">${applyLink}${contactLine}</div>`;
+}
+
+function render(opp) {
+  document.title = `Ekehi — ${opp.opportunity_title}`;
+  const deadlineDate = opp.application_deadline
+    ? new Date(opp.application_deadline)
+    : null;
+
+  root.innerHTML = `
+    ${breadcrumb(opp.reference_code)}
+    ${renderHeader(opp)}
+    ${renderStats(opp, deadlineDate)}
+    ${renderBody(opp)}
+    ${renderActions(opp)}
+  `;
+}
+
+function renderError(message) {
+  root.innerHTML = `${breadcrumb()}<p class="error-message">${message}</p>`;
+}
+
+async function loadOpportunity() {
+  const id = new URLSearchParams(window.location.search).get("id");
+
+  if (!id) {
+    renderError("No opportunity ID provided.");
+    return;
+  }
+
+  root.innerHTML = `<p class="loading">Loading opportunity…</p>`;
+
+  try {
+    const res = await api.get(`/opportunities/${id}`);
+    if (!res.data) {
+      renderError("Opportunity not found.");
+      return;
+    }
+    render(res.data);
+  } catch (e) {
+    renderError(`There was an error loading this opportunity. ${e.message}`);
+  }
+}
+
+loadOpportunity();

--- a/client/opportunities/detail/index.html
+++ b/client/opportunities/detail/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=DM+Serif+Text:ital@0;1&family=Urbanist:wght@300;400;500;600;700;800&display=swap"
+    />
+    <link rel="stylesheet" href="/shared/base/main.css" />
+    <link rel="stylesheet" href="detail.css" />
+    <title>Ekehi — Opportunity</title>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav id="nav-root" class="nav" aria-label="Main navigation"></nav>
+    </header>
+
+    <main class="container" id="detail-root">
+      <p class="loading">Loading opportunity…</p>
+    </main>
+
+    <footer id="footer-root" class="footer"></footer>
+    <script type="module" src="detail.js"></script>
+  </body>
+</html>

--- a/client/opportunities/opportunities.css
+++ b/client/opportunities/opportunities.css
@@ -27,6 +27,13 @@
   padding-top: var(--space-5);
   padding-bottom: var(--space-10);
   border-top: 1px solid var(--color-neutral-600);
+  /* reset anchor styles */
+  color: inherit;
+  text-decoration: none;
+}
+
+.opportunity-card:hover {
+  background-color: var(--color-neutral-50);
 }
 .opportunity-amount {
   flex: 0 0 200px;
@@ -54,31 +61,6 @@
   gap: 4px;
   font-size: var(--font-size-base);
   font-weight: var(--font-medium);
-}
-
-.badge {
-  font-size: var(--text-xs);
-  font-weight: var(--font-semibold);
-  text-align: center;
-  border-radius: 10px;
-}
-
-.badge--rolling_applications {
-  background-color: #ffede6;
-  color: #d75825;
-  width: 8rem;
-}
-
-.badge--open {
-  background-color: #f9e6ff;
-  color: #9900cc;
-  width: 4rem;
-}
-
-.badge--closed {
-  background-color: #ffe6e6;
-  color: #d72525;
-  width: 5rem;
 }
 
 .foundation-amount {

--- a/client/opportunities/opportunities.js
+++ b/client/opportunities/opportunities.js
@@ -3,6 +3,11 @@ import Dropdown from "/shared/components/dropdown/dropdown.js";
 import SearchBar from "/shared/components/search-bar/search-bar.js";
 import "/shared/components/nav/nav.js";
 import "/shared/components/footer/footer.js";
+import {
+  formatAmount,
+  daysUntil,
+  humanize,
+} from "/shared/utils/opportunity.utils.js";
 
 const previewDropdown = document.getElementById("preview-dropdown");
 const previewSearchbar = document.getElementById("preview-searchbar");
@@ -25,26 +30,10 @@ previewSearchbar.appendChild(
   SearchBar.create({ placeholder: "Search 30+ funding opportunities" }),
 );
 
-function formatAmount(min, max, currency) {
-  const fmt = (n) =>
-    n != null ? `${currency ?? ""}${(n / 1_000_000).toFixed(0)}m` : "—";
-  return `${fmt(min)} - ${fmt(max)}`;
-}
-
-function daysUntil(dateStr) {
-  if (!dateStr) return "—";
-  const diff = Math.ceil((new Date(dateStr) - Date.now()) / 86_400_000);
-  if (diff < 0) return "Closed";
-  if (diff === 0) return "Closes today";
-  return `${diff} days left`;
-}
-
 function closingSoon(dateStr, status) {
-  status = (status ?? "").replace(/_/g, " ");
-  if (!dateStr) return status;
+  if (!dateStr) return humanize(status);
   const diff = Math.ceil((new Date(dateStr) - Date.now()) / 86_400_000);
-  if (diff <= 10) status = "closing soon";
-  return status;
+  return diff <= 10 ? "closing soon" : humanize(status);
 }
 
 function populateOpportunities(opps) {
@@ -52,10 +41,10 @@ function populateOpportunities(opps) {
   opportunityCard.innerHTML = opps
     .map(
       (opp) => `
-     <div class="opportunity-card">
+     <a class="opportunity-card" href="/opportunities/detail/?id=${opp.id}">
       <div class="opportunity-amount">
         <p class="foundation-amount">${formatAmount(opp.amount_min, opp.amount_max, opp.currency)}</p>
-        <p class="foundation-type">${(opp.opportunity_type ?? "").replace(/_/g, " ")}</p>
+        <p class="foundation-type">${humanize(opp.opportunity_type)}</p>
       </div>
       <div class="opportunity-title">
         <div class="opportunity-title-tag">
@@ -66,9 +55,9 @@ function populateOpportunities(opps) {
       </div>
       <div class="opportunity-deadline">
         <img src="/assets/images/time-vector.png" alt="clock"/>
-        <p>${daysUntil(opp.application_deadline)}</p>
+        <p>${daysUntil(opp.application_deadline) ?? "—"}</p>
       </div>
-     </div>
+     </a>
      `,
     )
     .join("");

--- a/client/shared/base/utilities.css
+++ b/client/shared/base/utilities.css
@@ -382,6 +382,58 @@
   box-shadow: var(--shadow-xl);
 }
 
+/* Badges */
+.badge {
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  text-align: center;
+  border-radius: var(--radius-xl);
+  padding: var(--space-0-5) calc(var(--spacing) * 2.5);
+  white-space: nowrap;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.badge--rolling_applications {
+  background-color: #ffede6;
+  color: #d75825;
+  width: 8rem;
+}
+
+.badge--open {
+  background-color: #f9e6ff;
+  color: #9900cc;
+  width: 4rem;
+}
+
+.badge--closed {
+  background-color: #ffe6e6;
+  color: #d72525;
+  width: 5rem;
+}
+
+.badge--type {
+  color: var(--color-neutral-600);
+  background-color: var(--color-neutral-100);
+}
+
+.badge--flag {
+  color: var(--color-purple-700);
+  background-color: var(--color-purple-50);
+}
+
+.badge--tag {
+  font-weight: var(--font-medium);
+  color: var(--color-neutral-700);
+  background-color: var(--color-neutral-100);
+  border: 1px solid var(--color-neutral-300);
+  border-radius: 6px;
+  padding: 3px 10px;
+  text-transform: capitalize;
+}
+
 /* Others */
 .container {
   max-width: var(--container-wide);

--- a/client/shared/utils/opportunity.utils.js
+++ b/client/shared/utils/opportunity.utils.js
@@ -1,0 +1,37 @@
+const formatterCache = new Map();
+
+function getFormatter(currency) {
+  if (!formatterCache.has(currency)) {
+    formatterCache.set(
+      currency,
+      new Intl.NumberFormat("en", {
+        style: "currency",
+        currency,
+        currencyDisplay: "narrowSymbol",
+        notation: "compact",
+        maximumFractionDigits: 1,
+      }),
+    );
+  }
+  return formatterCache.get(currency);
+}
+
+export function formatAmount(min, max, currency) {
+  if (min == null && max == null) return "—";
+  const fmt = (n) => getFormatter(currency ?? "USD").format(n);
+  return min === max ? fmt(min) : `${fmt(min)} – ${fmt(max)}`;
+}
+
+/** Accepts a Date object or date string. Callers can pre-parse to avoid repeated parsing. */
+export function daysUntil(dateInput) {
+  if (!dateInput) return null;
+  const date = dateInput instanceof Date ? dateInput : new Date(dateInput);
+  const diff = Math.ceil((date - Date.now()) / 86_400_000);
+  if (diff < 0) return "Closed";
+  if (diff === 0) return "Closes today";
+  return `${diff} days left`;
+}
+
+export function humanize(str) {
+  return (str ?? "").replace(/_/g, " ");
+}


### PR DESCRIPTION
## Summary

- Closes #71
- Created `client/opportunities/detail/` — `index.html`, `detail.js`, `detail.css`
- Detail page reads the opportunity ID from `?id=` query param, fetches from `GET /opportunities/:id`, and renders full opportunity details including funding, deadline, country, description, eligibility, sectors, stages, apply link, and contact
- Opportunity cards on the listing page now link to `/opportunities/detail/?id=<id>`
- Extracted shared `formatAmount`, `daysUntil`, and `humanize` helpers into `client/shared/utils/opportunity.utils.js` to avoid duplication between the listing and detail pages
- `Intl.NumberFormat` is memoized per currency code to avoid repeated expensive instantiation
- `application_deadline` is parsed into a `Date` once per render and passed to both `formatDate` and `daysUntil` — no repeated string parsing
- `render` is composed of focused sub-functions (`renderHeader`, `renderStats`, `renderBody`, `renderActions`) — each with a single responsibility

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Linked Issue
Closes #71

## ClickUp Task (if applicable)
Link:

## Changes Made
- `client/opportunities/detail/index.html` — detail page HTML shell
- `client/opportunities/detail/detail.js` — fetches opportunity by ID, renders full detail view with loading/error states
- `client/opportunities/detail/detail.css` — page-specific styles using design tokens, fully responsive
- `client/opportunities/opportunities.js` — cards now wrapped in `<a>` linking to detail page; uses shared utils
- `client/opportunities/opportunities.css` — anchor style reset on `.opportunity-card`
- `client/shared/utils/opportunity.utils.js` — shared `formatAmount` (with cached `Intl.NumberFormat`), `daysUntil`, `humanize`

## Screenshots (for UI changes)
<!-- Add screenshots of the detail page on mobile and desktop -->

## Checklist
- [x] Branch is up to date with `development`
- [x] Code follows project conventions
- [x] No `.env` or secrets committed
- [ ] UI changes tested on mobile and desktop
- [x] Backend changes tested locally
- [x] PR is linked to an issue or ClickUp task