### PR TITLE
[frontend] feat: add training programmes list display from API

### DIFF
--- a/client/resources/resources.css
+++ b/client/resources/resources.css
@@ -1,0 +1,141 @@
+/* ==========================================================================
+   Training & Resources Page — resources.css
+   Block: .training-card, .trainings-grid, .results-header
+   References: tokens.css
+   ========================================================================== */
+
+/* ── Results header ─────────────────────────────────── */
+.results-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-6);
+}
+
+.results-header h2 {
+  font-family: var(--font-serif);
+  font-size: var(--text-2xl);
+  font-weight: var(--font-regular);
+  color: var(--color-text-primary);
+}
+
+.view-all-link {
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: color 120ms ease;
+}
+
+.view-all-link:hover {
+  color: var(--color-primary-hover);
+}
+
+/* ── Trainings grid — 3 columns ─────────────────────── */
+.trainings-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-6);
+  list-style: none;
+}
+
+/* ── training-card ──────────────────────────────────── */
+.training-card {
+  background-color: var(--color-bg-base);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2xl);
+  overflow: hidden;
+  transition: box-shadow 150ms ease, transform 150ms ease;
+}
+
+.training-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+}
+
+/* ── training-card__image — purple placeholder ──────── */
+.training-card__image {
+  background-color: var(--color-purple-50);
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}
+
+/* ── training-card__body ────────────────────────────── */
+.training-card__body {
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+/* ── training-card__meta — date + location badges ───── */
+.training-card__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.training-card__date,
+.training-card__location {
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-text-muted);
+  background-color: var(--color-bg-subtle);
+  border-radius: var(--radius-full);
+  padding: var(--space-1) var(--space-3);
+  white-space: nowrap;
+}
+
+/* ── training-card__title ───────────────────────────── */
+.training-card__title {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  line-height: var(--leading-snug);
+}
+
+/* ── training-card__provider ────────────────────────── */
+.training-card__provider {
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  line-height: var(--leading-normal);
+}
+
+/* ── Loading and error states ───────────────────────── */
+.loading-text,
+.error-message {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  color: var(--color-text-muted);
+  text-align: center;
+  padding: var(--space-12) var(--space-6);
+  grid-column: 1 / -1;
+}
+
+.error-message {
+  color: #c0392b;
+}
+
+/* ── Responsive ─────────────────────────────────────── */
+@media (max-width: 900px) {
+  .trainings-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .trainings-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .results-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
+}

--- a/client/resources/resources.js
+++ b/client/resources/resources.js
@@ -77,3 +77,80 @@ filterContainer.appendChild(Dropdown.create({
   ],
   onChange: (value) => onFilterChange('location_scope', value),
 }));
+
+// ── Helpers ────────────────────────────────────────────
+function formatDeadline(dateStr) {
+  if (!dateStr) return null;
+  return new Date(dateStr).toLocaleDateString('en-GB', {
+    day: 'numeric', month: 'long', year: 'numeric',
+  });
+}
+ 
+function formatDuration(range) {
+  const map = {
+    lt_1_week:       '< 1 week',
+    '1_4_weeks':     '1–4 weeks',
+    '1_3_months':    '1–3 months',
+    '3_plus_months': '3+ months',
+    self_paced:      'Self-paced',
+  };
+  return map[range] ?? range ?? '—';
+}
+ 
+// ── Card renderer ──────────────────────────────────────
+function renderTrainingCard(programme) {
+  const card = document.createElement('div');
+  card.className = 'training-card';
+ 
+  card.innerHTML = `
+    <div class="training-card__image"></div>
+    <div class="training-card__body">
+      <div class="training-card__meta">
+        ${programme.application_deadline
+          ? `<span class="training-card__date">${formatDeadline(programme.application_deadline)}</span>`
+          : ''}
+        <span class="training-card__location">${programme.location_scope ?? '—'}</span>
+      </div>
+      <h3 class="training-card__title">${programme.programme_name}</h3>
+      <p class="training-card__provider">${programme.provider}</p>
+    </div>
+  `;
+ 
+  return card;
+}
+ 
+// ── Section header renderer ────────────────────────────
+function renderTrainingsHeader(total) {
+  const existing = document.getElementById('results-count');
+  if (existing) { existing.textContent = 'Training & Events'; return; }
+ 
+  const header = document.createElement('div');
+  header.className = 'results-header';
+  header.innerHTML = `
+    <h2 id="results-count">Training &amp; Events</h2>
+    <a href="#" class="view-all-link">View all events</a>
+  `;
+  document.querySelector('.results-section').prepend(header);
+}
+ 
+// ── Fetch and render trainings ─────────────────────────
+async function loadTrainings() {
+  const list = document.getElementById('trainings-list');
+ 
+  list.innerHTML = '<p class="loading-text">Loading...</p>';
+ 
+  try {
+    const res = await api.get('/trainings?limit=20');
+    const programmes = res.data ?? [];
+    const total = res.meta?.total ?? programmes.length;
+ 
+    renderTrainingsHeader(total);
+    list.className = 'trainings-grid';
+    list.innerHTML = '';
+    programmes.forEach((p) => list.appendChild(renderTrainingCard(p)));
+  } catch (err) {
+    list.innerHTML = `<p class="error-message">${err.message}</p>`;
+  }
+}
+ 
+loadTrainings();


### PR DESCRIPTION
## Summary
Extends resources.js with fetch and render logic for the training programmes list display. On page load, GET /trainings is called and results are rendered as cards in a 3-column responsive grid. Includes a loading state while the request is in flight and an error state if the API call fails. Adds resources.css for card and grid styles.

## Type of Change
- [x] Feature

## Linked Issue
Closes #61 

## Changes Made
- Added formatDeadline() and formatDuration() helper functions
- Added renderTrainingCard() — builds each card with image placeholder, 
  date badge, location badge, programme name, and provider
- Added renderTrainingsHeader() — renders "Training & Events" heading and 
  "View all events" link above the grid
- Added loadTrainings() — fetches GET /trainings?limit=20 on page load, 
  handles loading and error states
- Added resources.css with BEM card styles, 3-column responsive grid, 
  loading and error state styles

## Checklist
- [x] Branch is up to date with development
- [x] Code follows project conventions
- [x] No .env or secrets committed
- [x] UI changes tested on mobile and desktop
- [ ] Backend changes tested locally
- [x] PR is linked to an issue or ClickUp task