### PR TITLE
[frontend] feat: update navigation — add Submissions link and Post a Job button

### DIFF
--- a/client/shared/components/nav/nav.js
+++ b/client/shared/components/nav/nav.js
@@ -16,10 +16,13 @@ const NAV_CONFIG = {
     { href: "/contributors/", label: "Contributors" },
     { href: "/opportunities/", label: "Opportunities" },
     { href: "/resources/", label: "Resources" },
+    { href: "#", label: "Submissions" },
   ],
   cta: {
     signup: { href: "/signup/", label: "Sign up" },
     login: { href: "/login/", label: "Log in" },
+    postjobs: { href: "#", label: "Post a job" },
+
   },
 };
 
@@ -80,8 +83,11 @@ class NavComponent {
     logoutBtn.setAttribute("role", "menuitem");
     logoutBtn.textContent = "Log out";
     logoutBtn.addEventListener("click", () => this.#logout());
+    
 
     menu.appendChild(logoutBtn);
+    
+
 
     btn.addEventListener("click", (e) => {
       e.stopPropagation();
@@ -170,12 +176,21 @@ class NavComponent {
     return ul;
   }
 
-  #buildDesktopCTA({ signup, login }) {
+  #buildDesktopCTA({ signup, login, postjobs }) {
     const wrapper = document.createElement("div");
     wrapper.className = "nav__cta";
     wrapper.setAttribute("aria-label", "Account actions");
 
     if (this.#isLoggedIn()) {
+      wrapper.appendChild(
+      Button.create({
+        label: postjobs.label,
+        variant: "outline",
+        size: "sm",
+        as: "a",
+        href: postjobs.href,
+      })
+    ),
       wrapper.appendChild(this.#buildAvatar());
       return wrapper;
     }
@@ -198,7 +213,16 @@ class NavComponent {
         href: login.href,
       }),
     );
-
+     wrapper.appendChild(
+      Button.create({
+        label: postjobs.label,
+        variant: "outline",
+        size: "sm",
+        as: "a",
+        href: postjobs.href,
+      }),
+    );
+    
     return wrapper;
   }
 


### PR DESCRIPTION
## Summary
The global navigation has been updated to contain a Submissions link and a Post a Job button, with distinct logged-in and logged-out states.

LOGGED IN STATE
<img width="1886" height="316" alt="Screenshot 2026-03-18 152735" src="https://github.com/user-attachments/assets/814f6d72-f7bb-4cf1-9a08-a1108379a709" />

LOGGED OUT STATE
<img width="1856" height="316" alt="Screenshot 2026-03-18 152816" src="https://github.com/user-attachments/assets/82993e9f-bc48-4719-bbaf-3ea1073211a6" />


## Type of Change
- [x] Feature✅
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore / refactor


## Linked Issue
Closes #84


## ClickUp Task (if applicable)
Link:


## Changes Made
"Submissions" added as 4th nav link

"Post a job" button added with outline style, and it's visible to all users

Logged-out state: Sign up (filled) + Log in (outline) + Post a job (outline)

Logged-in state: Post a job (outline) + Avatar dropdown



## Checklist
- [x] Branch is up to date with `development`
- [x] Code follows project conventions
- [x] No `.env` or secrets committed
- [x] UI changes tested on mobile and desktop
- [ ] Backend changes tested locally
- [x] PR is linked to an issue or ClickUp task
