### PR TITLE
feat[frontend]: Implement step 1 for multi flow of sign up

### DIFF
--- a/client/signup/index.html
+++ b/client/signup/index.html
@@ -19,26 +19,49 @@
     </header>
 
     <main class="auth-container">
-      <img src="/assets/logo.svg" alt="Ekehi" class="auth-logo" />
-      <h1 class="auth-title">Create your account</h1>
-      <p class="auth-subtitle">
-        Join us today and create your account to begin your journey!
-      </p>
-
-      <form id="signup-form" novalidate>
-        <div id="firstname-field"></div>
-        <div id="lastname-field"></div>
-        <div id="email-field"></div>
-        <div id="password-field"></div>
-        <div id="submit-btn"></div>
-        <p id="signup-error" class="auth-error" hidden></p>
-      </form>
-
-      <p class="auth-terms">
-        By clicking Continue, you acknowledge that you have read and agree with
-        Ekehi's <a href="/terms">Terms</a> and
-        <a href="/privacy">Privacy Policy</a>.
-      </p>
+ 
+      <img src="../assets/icons/logo2.png" alt="Ekehi" class="auth-logo" />
+ 
+      <!-- Step 1: email + full name -->
+      <div id="signup-step-1" class="auth-step">
+        <h1 class="auth-title">Create your account</h1>
+        <p class="auth-subtitle">
+          Join us today and create your account to begin your journey!
+        </p>
+ 
+        <form id="signup-form-step1" class="auth-form" novalidate>
+          <div id="email-field"></div>
+          <div id="fullname-field"></div>
+          <div id="continue-btn"></div>
+          <p id="signup-error-1" class="auth-error" hidden></p>
+        </form>
+ 
+        <button type="button" id="back-btn-1" class="auth-btn-back">Back</button>
+ 
+        <p class="auth-terms">
+          By clicking Continue, you acknowledge that you have read and agree with
+          Ekehi's <a href="/terms" class="auth-terms__link">Terms</a> and
+          <a href="/privacy" class="auth-terms__link">Privacy Policy</a>.
+        </p>
+      </div>
+ 
+      <!-- Step 2: password + confirm password -->
+      <div id="signup-step-2" class="auth-step" hidden>
+        <h1 class="auth-title">Create your password</h1>
+        <p class="auth-subtitle">
+          Create your password. It should be unique and strong.
+        </p>
+ 
+        <form id="signup-form-step2" class="auth-form" novalidate>
+          <div id="password-field"></div>
+          <div id="confirm-password-field"></div>
+          <div id="submit-btn"></div>
+          <p id="signup-error-2" class="auth-error" hidden></p>
+        </form>
+ 
+        <button type="button" id="back-btn-2" class="auth-btn-back">Back</button>
+      </div>
+ 
     </main>
 
     <footer id="footer-root" class="footer"></footer>

--- a/client/signup/signup.js
+++ b/client/signup/signup.js
@@ -4,84 +4,74 @@ import Input from "/shared/components/input/input.js";
 import "/shared/components/nav/nav.js";
 import "/shared/components/footer/footer.js";
 
-// 1. Mount components
-document
-  .getElementById("firstname-field")
-  .appendChild(
-    Input.create({
-      type: "text",
-      placeholder: "Enter first name",
-      name: "firstName",
-      variant: "filled",
-      required: true,
-    }),
-  );
+// ── Redirect if already logged in ─────────────────────
+if (AuthService.isLoggedIn()) {
+  window.location.href = '/opportunities/';
+}
 
-document
-  .getElementById("lastname-field")
-  .appendChild(
-    Input.create({
-      type: "text",
-      placeholder: "Enter last name",
-      name: "lastName",
-      variant: "filled",
-      required: true,
-    }),
-  );
+// ── Step references ────────────────────────────────────
+const step1 = document.getElementById('signup-step-1');
 
-document
-  .getElementById("email-field")
-  .appendChild(
-    Input.create({
-      type: "email",
-      placeholder: "Enter email address",
-      name: "email",
-      variant: "filled",
-      required: true,
-    }),
-  );
 
-document
-  .getElementById("password-field")
-  .appendChild(
-    Input.createPassword({
-      placeholder: "Confirm password",
-      name: "password",
-      variant: "filled",
-    }),
-  );
+// ── Mount Step 1 components ────────────────────────────
+document.getElementById('email-field').appendChild(
+  Input.create({
+    type: 'email',
+    placeholder: 'Email address',
+    name: 'email',
+    variant: 'filled',
+    required: true,
+  })
+);
 
-document
-  .getElementById("submit-btn")
-  .appendChild(
-    Button.create({
-      label: "Create account",
-      variant: "primary",
-      full: true,
-      type: "submit",
-    }),
-  );
+document.getElementById('fullname-field').appendChild(
+  Input.create({
+    type: 'text',
+    placeholder: 'Full name',
+    name: 'fullname',
+    variant: 'filled',
+    required: true,
+  })
+);
 
-// 2. Handle submit
-document.getElementById("signup-form").addEventListener("submit", async (e) => {
-  e.preventDefault();
-  const firstName = e.target.querySelector('[name="firstName"]').value.trim();
-  const lastName = e.target.querySelector('[name="lastName"]').value.trim();
-  const email = e.target.querySelector('[name="email"]').value.trim();
-  const password = e.target.querySelector('[name="password"]').value;
-  const errorEl = document.getElementById("signup-error");
-  const submitBtn = document.querySelector("#submit-btn button");
+document.getElementById('continue-btn').appendChild(
+  Button.create({
+    label: 'Continue',
+    variant: 'primary',
+    full: true,
+    type: 'button',
+  })
+);
+
+// ── Step 1 — Continue ──────────────────────────────────
+document.getElementById('continue-btn').addEventListener('click', () => {
+  const email    = document.querySelector('[name="email"]').value.trim();
+  const fullname = document.querySelector('[name="fullname"]').value.trim();
+  const errorEl  = document.getElementById('signup-error-1');
 
   errorEl.hidden = true;
-  submitBtn.disabled = true;
+  errorEl.textContent = '';
 
-  try {
-    await AuthService.signup(email, password, firstName, lastName);
-    window.location.href = "/opportunities/";
-  } catch (err) {
-    errorEl.textContent = err.message || "Sign up failed. Please try again.";
+  if (!email || !fullname) {
+    errorEl.textContent = 'Please fill in all fields.';
     errorEl.hidden = false;
-  } finally {
-    submitBtn.disabled = false;
+    return;
   }
+
+  step1.hidden = true;
+  step2.hidden = false;
 });
+
+// ── Step 1 — Back (go to login) ────────────────────────
+document.getElementById('back-btn-1').addEventListener('click', () => {
+  window.location.href = '/client/login/index.html';
+});
+
+  const fullname        = document.querySelector('[name="fullname"]').value.trim();
+  const email           = document.querySelector('[name="email"]').value.trim();
+
+  errorEl.hidden = true;
+  errorEl.textContent = '';
+
+  const [firstName, ...rest] = fullname.split(' ');
+  const lastName = rest.join(' ') || '';

--- a/client/signup/signup.js
+++ b/client/signup/signup.js
@@ -1,8 +1,7 @@
 import AuthService from "/shared/services/auth.service.js";
 import Button from "/shared/components/button/button.js";
 import Input from "/shared/components/input/input.js";
-import "/shared/components/nav/nav.js";
-import "/shared/components/footer/footer.js";
+
 
 // ── Redirect if already logged in ─────────────────────
 if (AuthService.isLoggedIn()) {


### PR DESCRIPTION
## Summary
Redesigns the signup page to a centred card layout with no nav or footer, 
matching the updated auth UI design. Restructures the single-step form into 
a two-step flow — Step 1 collects email and full name, Step 2 collects 
password and confirm password. Adds the Ekehi app icon, step navigation 
with Continue and Back buttons, and a terms notice with purple links.

## Type of Change
- [x] Feature

## Linked Issue
Closes #92

## ClickUp Task (if applicable)
Link:

## Changes Made
- Removed nav and footer from index.html
- Restructured main content into two auth-step divs [step 2 hidden not implemented in this issue]
- Added auth-logo, auth-title, auth-subtitle classes matching the new design
- Setup signup.js to handle step transitions
- Kept ES module import pattern and AuthService.signup() call from original

## Screenshots (for UI changes)
<!-- Add before/after screenshots or a screen recording -->

## Checklist
- [x] Branch is up to date with development
- [x] Code follows project conventions
- [x] No .env or secrets committed
- [x] UI changes tested on mobile and desktop
- [ ] Backend changes tested locally
- [x] PR is linked to an issue or ClickUp task