### PR TITLE
feat[frontend]: Implement password as step 2 of sign up flow

### DIFF
--- a/client/signup/index.html
+++ b/client/signup/index.html
@@ -14,35 +14,54 @@
     <title>Sign up - Ekehi</title>
   </head>
   <body>
-    <header class="site-header">
-      <nav id="nav-root" class="nav" aria-label="Main navigation"></nav>
-    </header>
 
     <main class="auth-container">
-      <img src="/assets/logo.svg" alt="Ekehi" class="auth-logo" />
-      <h1 class="auth-title">Create your account</h1>
-      <p class="auth-subtitle">
-        Join us today and create your account to begin your journey!
-      </p>
 
-      <form id="signup-form" novalidate>
-        <div id="firstname-field"></div>
-        <div id="lastname-field"></div>
-        <div id="email-field"></div>
-        <div id="password-field"></div>
-        <div id="submit-btn"></div>
-        <p id="signup-error" class="auth-error" hidden></p>
-      </form>
+      <img src="../assets/icons/logo2.png" alt="Ekehi" class="auth-logo" />
 
-      <p class="auth-terms">
-        By clicking Continue, you acknowledge that you have read and agree with
-        Ekehi's <a href="/terms">Terms</a> and
-        <a href="/privacy">Privacy Policy</a>.
-      </p>
+      <!-- Step 1: email + full name -->
+      <div id="signup-step-1" class="auth-step">
+        <h1 class="auth-title">Create your account</h1>
+        <p class="auth-subtitle">
+          Join us today and create your account to begin your journey!
+        </p>
+
+        <form id="signup-form-step1" class="auth-form" novalidate>
+          <div id="email-field"></div>
+          <div id="fullname-field"></div>
+          <div id="continue-btn"></div>
+          <p id="signup-error-1" class="auth-error" hidden></p>
+        </form>
+
+        <button type="button" id="back-btn-1" class="auth-btn-back">Back</button>
+
+        <p class="auth-terms">
+          By clicking Continue, you acknowledge that you have read and agree with
+          Ekehi's <a href="/terms" class="auth-terms__link">Terms</a> and
+          <a href="/privacy" class="auth-terms__link">Privacy Policy</a>.
+        </p>
+      </div>
+
+      <!-- Step 2: password + confirm password -->
+      <div id="signup-step-2" class="auth-step" hidden>
+        <h1 class="auth-title">Create your password</h1>
+        <p class="auth-subtitle">
+          Create your password. It should be unique and strong.
+        </p>
+
+        <form id="signup-form-step2" class="auth-form" novalidate>
+          <div id="password-field"></div>
+          <div id="confirm-password-field"></div>
+          <div id="submit-btn"></div>
+          <p id="signup-error-2" class="auth-error" hidden></p>
+        </form>
+
+        <button type="button" id="back-btn-2" class="auth-btn-back">Back</button>
+      </div>
+
     </main>
 
-    <footer id="footer-root" class="footer"></footer>
-
     <script type="module" src="signup.js"></script>
+
   </body>
 </html>

--- a/client/signup/signup.js
+++ b/client/signup/signup.js
@@ -1,85 +1,132 @@
-import AuthService from "/shared/services/auth.service.js";
-import Button from "/shared/components/button/button.js";
-import Input from "/shared/components/input/input.js";
-import "/shared/components/nav/nav.js";
-import "/shared/components/footer/footer.js";
+import AuthService from '/shared/services/auth.service.js';
+import Button from '/shared/components/button/button.js';
+import Input from '/shared/components/input/input.js';
 
-// 1. Mount components
-document
-  .getElementById("firstname-field")
-  .appendChild(
-    Input.create({
-      type: "text",
-      placeholder: "Enter first name",
-      name: "firstName",
-      variant: "filled",
-      required: true,
-    }),
-  );
+// ── Redirect if already logged in ─────────────────────
+if (AuthService.isLoggedIn()) {
+  window.location.href = '/opportunities/';
+}
 
-document
-  .getElementById("lastname-field")
-  .appendChild(
-    Input.create({
-      type: "text",
-      placeholder: "Enter last name",
-      name: "lastName",
-      variant: "filled",
-      required: true,
-    }),
-  );
+// ── Step references ────────────────────────────────────
+const step1 = document.getElementById('signup-step-1');
+const step2 = document.getElementById('signup-step-2');
 
-document
-  .getElementById("email-field")
-  .appendChild(
-    Input.create({
-      type: "email",
-      placeholder: "Enter email address",
-      name: "email",
-      variant: "filled",
-      required: true,
-    }),
-  );
+// ── Mount Step 1 components ────────────────────────────
+document.getElementById('email-field').appendChild(
+  Input.create({
+    type: 'email',
+    placeholder: 'Email address',
+    name: 'email',
+    variant: 'filled',
+    required: true,
+  })
+);
 
-document
-  .getElementById("password-field")
-  .appendChild(
-    Input.createPassword({
-      placeholder: "Confirm password",
-      name: "password",
-      variant: "filled",
-    }),
-  );
+document.getElementById('fullname-field').appendChild(
+  Input.create({
+    type: 'text',
+    placeholder: 'Full name',
+    name: 'fullname',
+    variant: 'filled',
+    required: true,
+  })
+);
 
-document
-  .getElementById("submit-btn")
-  .appendChild(
-    Button.create({
-      label: "Create account",
-      variant: "primary",
-      full: true,
-      type: "submit",
-    }),
-  );
+document.getElementById('continue-btn').appendChild(
+  Button.create({
+    label: 'Continue',
+    variant: 'primary',
+    full: true,
+    type: 'button',
+  })
+);
 
-// 2. Handle submit
-document.getElementById("signup-form").addEventListener("submit", async (e) => {
-  e.preventDefault();
-  const firstName = e.target.querySelector('[name="firstName"]').value.trim();
-  const lastName = e.target.querySelector('[name="lastName"]').value.trim();
-  const email = e.target.querySelector('[name="email"]').value.trim();
-  const password = e.target.querySelector('[name="password"]').value;
-  const errorEl = document.getElementById("signup-error");
-  const submitBtn = document.querySelector("#submit-btn button");
+// ── Mount Step 2 components ────────────────────────────
+document.getElementById('password-field').appendChild(
+  Input.createPassword({
+    placeholder: 'Password',
+    name: 'password',
+    variant: 'filled',
+  })
+);
+
+document.getElementById('confirm-password-field').appendChild(
+  Input.createPassword({
+    placeholder: 'Confirm password',
+    name: 'confirmPassword',
+    variant: 'filled',
+  })
+);
+
+document.getElementById('submit-btn').appendChild(
+  Button.create({
+    label: 'Sign up',
+    variant: 'primary',
+    full: true,
+    type: 'submit',
+  })
+);
+
+// ── Step 1 — Continue ──────────────────────────────────
+document.getElementById('continue-btn').addEventListener('click', () => {
+  const email    = document.querySelector('[name="email"]').value.trim();
+  const fullname = document.querySelector('[name="fullname"]').value.trim();
+  const errorEl  = document.getElementById('signup-error-1');
 
   errorEl.hidden = true;
+  errorEl.textContent = '';
+
+  if (!email || !fullname) {
+    errorEl.textContent = 'Please fill in all fields.';
+    errorEl.hidden = false;
+    return;
+  }
+
+  step1.hidden = true;
+  step2.hidden = false;
+});
+
+// ── Step 1 — Back (go to login) ────────────────────────
+document.getElementById('back-btn-1').addEventListener('click', () => {
+  window.location.href = '/client/login/index.html';
+});
+
+// ── Step 2 — Back (return to step 1) ──────────────────
+document.getElementById('back-btn-2').addEventListener('click', () => {
+  step2.hidden = true;
+  step1.hidden = false;
+});
+
+// ── Step 2 — Submit ────────────────────────────────────
+document.getElementById('signup-form-step2').addEventListener('submit', async (e) => {
+  e.preventDefault();
+
+  const fullname        = document.querySelector('[name="fullname"]').value.trim();
+  const email           = document.querySelector('[name="email"]').value.trim();
+  const password        = document.querySelector('[name="password"]').value;
+  const confirmPassword = document.querySelector('[name="confirmPassword"]').value;
+  const errorEl         = document.getElementById('signup-error-2');
+  const submitBtn       = document.querySelector('#submit-btn button');
+
+  errorEl.hidden = true;
+  errorEl.textContent = '';
+
+  if (password !== confirmPassword) {
+    errorEl.textContent = 'Passwords do not match.';
+    errorEl.hidden = false;
+    return;
+  }
+
+  const [firstName, ...rest] = fullname.split(' ');
+  const lastName = rest.join(' ') || '';
+
   submitBtn.disabled = true;
 
   try {
     await AuthService.signup(email, password, firstName, lastName);
-    window.location.href = "/opportunities/";
+    window.location.href = '/opportunities/';
   } catch (err) {
-    errorEl.textContent = err.message || "Sign up failed. Please try again.";
+    errorEl.textContent = err.message || 'Sign up failed. Please try again.';
     errorEl.hidden = false;
   } finally {
     submitBtn.disabled = false;


### PR DESCRIPTION
## Summary
Restructure the single-step form into a two-step flow — Step 1 already collects email and full name, Step 2 collects password and confirm password. Adds step navigation with Continue and Back buttons

## Type of Change
- [x] Feature

## Linked Issue
Closes #93 

## ClickUp Task (if applicable)
Link:

## Changes Made
- Removed nav and footer from index.html
- Restructured main content into two auth-step divs with step 2 hidden by default
- Replaced single form with two separate forms for each step
- Added auth-logo, auth-title, auth-subtitle classes matching the new design
- Updated signup.js to handle step transitions, Continue validation, Back navigation, and password match check
- Kept ES module import pattern and AuthService.signup() call from original

## Screenshots (for UI changes)
<!-- Add before/after screenshots or a screen recording -->

## Checklist
- [x] Branch is up to date with development
- [x] Code follows project conventions
- [x] No .env or secrets committed
- [x] UI changes tested on mobile and desktop
- [ ] Backend changes tested locally
- [x] PR is linked to an issue or ClickUp task