### PR TITLE
Bug-fix[frontend]: Include a feature to hide the second step of the form

### DIFF
--- a/client/signup/signup.css
+++ b/client/signup/signup.css
@@ -120,3 +120,6 @@ body {
     padding-inline: var(--space-5);
   }
 }
+.auth-step[hidden] {
+  display: none;
+}


### PR DESCRIPTION
## Summary
fixed bug that displayed both steps on the initisl signup flow

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Linked Issue
Closes #

## ClickUp Task (if applicable)
Link:

## Changes Made
- force hide on .auth-step
- implement padding to fix form centering

## Screenshots (for UI changes)
<!-- Add before/after screenshots or a screen recording -->

## Checklist
- [x] Branch is up to date with `development`
- [x] Code follows project conventions
- [x] No `.env` or secrets committed
- [x] UI changes tested on mobile and desktop
- [ ] Backend changes tested locally
- [ ] PR is linked to an issue or ClickUp task
