### PR TITLE
[frontend] enhancement: adjusts hero-section title

### DIFF
--- a/client/landing/sections/hero.css
+++ b/client/landing/sections/hero.css
@@ -52,6 +52,7 @@ p {
   font-size: var(--text-5xl);
   font-weight: var(--font-regular);
   text-wrap: pretty;
+  text-transform: capitalize;
 }
 
 .hero__content-paragraph {
@@ -78,12 +79,16 @@ p {
   }
 
   .hero__content-title {
-    text-align: right;
     text-wrap: balance;
-    max-width: 80%;
-    margin-left: auto;
+    max-width: 85%;
+    margin-right: auto;
   }
 
+  .hero__content-title, .hero__content-paragraph, .hero__btns{
+    text-align: left;
+    justify-content: flex-start;
+  }
+  
   .nav__toggle-bar {
     background-color: white;
   }
@@ -94,8 +99,4 @@ p {
   }
 }
 
-@media screen and (max-width: 640px) {
-  .hero__btns {
-    justify-content: center;
-  }
-}
+


### PR DESCRIPTION
## Summary
Realigns hero title, paragraph and buttons to the left rather than the right on mobile. 

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Linked Issue
Closes #<!-- issue number -->

## ClickUp Task (if applicable)
Link:

## Changes Made
<!-- List key changes -->
- adjusts the width of the hero title
- aligns the hero title, paragraph, and buttons to the left
- capitalizes the hero title (I honestly think it looks better this way, especially with the font)

## Screenshots (for UI changes)
<img width="251" height="337" alt="image" src="https://github.com/user-attachments/assets/1cc3c8ef-2d75-49f7-9531-1b7b7ab0f1a4" />

## Checklist
- [x] Branch is up to date with `development`
- [x] Code follows project conventions
- [x] No `.env` or secrets committed
- [x] UI changes tested on mobile and desktop
- [x] Backend changes tested locally
- [x] PR is linked to an issue or ClickUp task
