### PR TITLE
feat: add loading skeleton component for opportunity and training lists

### DIFF
--- a/client/opportunities/opportunities.js
+++ b/client/opportunities/opportunities.js
@@ -2,6 +2,7 @@ import api from "/shared/services/api.js";
 import AuthService from "/shared/services/auth.service.js";
 import Dropdown from "/shared/components/dropdown/dropdown.js";
 import SearchBar from "/shared/components/search-bar/search-bar.js";
+import LoadingSkeleton from "/shared/components/loading-skeleton/loading-skeleton.js";
 import "/shared/components/nav/nav.js";
 import "/shared/components/footer/footer.js";
 import {
@@ -120,7 +121,7 @@ function populateOpportunities(opps) {
 }
 
 async function loadOpportunities() {
-  opportunityCards.innerHTML = `<p class='loading'>Loading Opportunities</p>`;
+  opportunityCards.innerHTML = LoadingSkeleton.render("opportunity", 5);
   try {
     const res = await api.get(`/opportunities${buildQueryString(filters)}`);
     const opportunities = res.data ?? [];
@@ -140,7 +141,7 @@ async function loadOpportunities() {
 }
 
 async function loadSavedOpportunities() {
-  opportunityCards.innerHTML = `<p class='loading'>Loading saved opportunities…</p>`;
+  opportunityCards.innerHTML = LoadingSkeleton.render("opportunity", 5);
   try {
     const res = await api.get("/opportunities/saved");
     const opportunities = res.data ?? [];

--- a/client/resources/resources.js
+++ b/client/resources/resources.js
@@ -1,6 +1,7 @@
 import api from "/shared/services/api.js";
 import Dropdown from "/shared/components/dropdown/dropdown.js";
 import SearchBar from "/shared/components/search-bar/search-bar.js";
+import LoadingSkeleton from "/shared/components/loading-skeleton/loading-skeleton.js";
 import "/shared/components/nav/nav.js";
 import "/shared/components/footer/footer.js";
 import {
@@ -119,7 +120,7 @@ const list = document.getElementById("trainings-list");
 list.className = "trainings-grid";
 
 async function loadTrainings() {
-  list.innerHTML = '<p class="loading-text">Loading...</p>';
+  list.innerHTML = LoadingSkeleton.render("training", 6);
 
   try {
     const res = await api.get(`/trainings${buildQueryString(filters)}`);

--- a/client/shared/base/main.css
+++ b/client/shared/base/main.css
@@ -13,3 +13,4 @@
 @import "../components/search-bar/search-bar.css";
 @import "../components/nav/nav.css";
 @import "../components/footer/footer.css";
+@import "../components/loading-skeleton/loading-skeleton.css";

--- a/client/shared/components/loading-skeleton/loading-skeleton.css
+++ b/client/shared/components/loading-skeleton/loading-skeleton.css
@@ -72,6 +72,7 @@
   }
   
   .opportunity-amount-sk,
+  .opportunity-body-sk,
   .opportunity-deadline-sk {
     flex: 1;
     width: 100%;

--- a/client/shared/components/loading-skeleton/loading-skeleton.css
+++ b/client/shared/components/loading-skeleton/loading-skeleton.css
@@ -1,0 +1,125 @@
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.skeleton-shimmer {
+  background: var(--color-neutral-100);
+  background: linear-gradient(90deg, var(--color-neutral-100) 25%, var(--color-neutral-200) 50%, var(--color-neutral-100) 75%);
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 2s infinite linear;
+}
+
+.skeleton-line {
+  background-color: var(--color-neutral-200);
+  border-radius: var(--radius-sm);
+  width: 100%;
+}
+
+.skeleton-line.short { width: 40%; }
+.skeleton-line.medium { width: 70%; }
+.skeleton-line.long { width: 90%; }
+.skeleton-line.full { width: 100%; }
+
+.skeleton-icon {
+  background-color: var(--color-neutral-200);
+  border-radius: var(--radius-full);
+}
+
+/* Specific to opportunities */
+.opportunity-skeleton {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding-block: var(--space-8);
+  border-top: 1px solid var(--color-border);
+  margin-inline: calc(var(--space-4) * -1);
+  padding-inline: var(--space-4);
+  pointer-events: none;
+  user-select: none;
+}
+
+.opportunity-amount-sk {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  flex: 0 0 200px;
+}
+
+.opportunity-body-sk {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.opportunity-deadline-sk {
+  flex: 0 0 200px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+@media screen and (max-width: 768px) {
+  .opportunity-skeleton {
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+  
+  .opportunity-amount-sk,
+  .opportunity-deadline-sk {
+    flex: 1;
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+/* Specific to trainings */
+.training-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  width: 100%;
+  pointer-events: none;
+  user-select: none;
+}
+
+.training-skeleton__display {
+  width: 100%;
+  border-radius: var(--radius-2xl);
+  aspect-ratio: 352 / 226;
+  background-color: var(--color-neutral-100);
+}
+
+.training-skeleton__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.training-skeleton__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.training-skeleton__meta .skeleton-line {
+  width: 80px;
+  height: var(--space-3);
+}
+
+.training-skeleton__title {
+  height: var(--space-6);
+  width: 80%;
+  margin-block: var(--space-1);
+}
+
+.training-skeleton__desc {
+  height: var(--space-4);
+  width: 100%;
+}

--- a/client/shared/components/loading-skeleton/loading-skeleton.js
+++ b/client/shared/components/loading-skeleton/loading-skeleton.js
@@ -1,0 +1,48 @@
+class LoadingSkeleton {
+  static opportunity() {
+    return `
+      <div class="opportunity-skeleton">
+        <div class="opportunity-amount-sk">
+          <div class="skeleton-line skeleton-shimmer short" style="height: 24px;"></div>
+          <div class="skeleton-line skeleton-shimmer medium" style="height: 16px;"></div>
+        </div>
+        <div class="opportunity-body-sk">
+          <div class="skeleton-line skeleton-shimmer long" style="height: 28px; max-width: 400px;"></div>
+          <div class="skeleton-line skeleton-shimmer medium" style="height: 16px; margin-top: 8px;"></div>
+        </div>
+        <div class="opportunity-deadline-sk">
+          <div class="skeleton-icon skeleton-shimmer" style="width: 20px; height: 20px;"></div>
+          <div class="skeleton-line skeleton-shimmer" style="width: 80px; height: 16px;"></div>
+        </div>
+      </div>
+    `;
+  }
+
+  static training() {
+    return `
+      <div class="training-skeleton">
+        <div class="training-skeleton__display skeleton-shimmer"></div>
+        <div class="training-skeleton__body">
+          <div class="training-skeleton__meta">
+            <div class="skeleton-line skeleton-shimmer"></div>
+            <div class="skeleton-line skeleton-shimmer"></div>
+          </div>
+          <div class="skeleton-line training-skeleton__title skeleton-shimmer"></div>
+          <div class="skeleton-line training-skeleton__desc skeleton-shimmer"></div>
+          <div class="skeleton-line training-skeleton__desc short skeleton-shimmer"></div>
+        </div>
+      </div>
+    `;
+  }
+
+  static render(type, count = 3) {
+    if (type === 'opportunity') {
+      return Array.from({ length: count }).map(() => this.opportunity()).join('');
+    } else if (type === 'training') {
+      return Array.from({ length: count }).map(() => this.training()).join('');
+    }
+    return '';
+  }
+}
+
+export default LoadingSkeleton;


### PR DESCRIPTION
## Summary
The Opportunity and Training lists show a loading skeleton when the data is being fetched.

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Linked Issue
Closes #125 

## ClickUp Task (if applicable)
Link:

## Changes Made
- Added a LoadingSkeleton component to the shared components folder. (css, js)
- Implement the LoadingSkeleton component to the Opportunity and Training lists when the API request is pending.

## Screenshots (for UI changes)
<img width="2078" height="1569" alt="Screenshot 2026-03-25 143013" src="https://github.com/user-attachments/assets/2f34dec9-d620-4704-9b6e-fe8a881265b5" />
<img width="611" height="1744" alt="Screenshot 2026-03-25 143024" src="https://github.com/user-attachments/assets/841afb6b-90d1-41cc-8cd4-2d3acecf7ad4" />
<img width="1864" height="1699" alt="Screenshot 2026-03-25 143124" src="https://github.com/user-attachments/assets/82310957-14b6-4945-a18b-474e6ed48565" />
<img width="576" height="1808" alt="Screenshot 2026-03-25 143139" src="https://github.com/user-attachments/assets/edc99201-d39b-4b04-ba5c-c41111a149f9" />




## Checklist
- [x] Branch is up to date with `development`
- [x] Code follows project conventions
- [x] No `.env` or secrets committed
- [x] UI changes tested on mobile and desktop
- [ ] Backend changes tested locally
- [x] PR is linked to an issue or ClickUp task
