### PR TITLE
feat: build details page for guides

### DIFF
--- a/client/resources/guides/detail/detail.css
+++ b/client/resources/guides/detail/detail.css
@@ -2,7 +2,7 @@
   display: grid;
   grid-template-columns: 250px 1fr;
   gap: var(--space-16);
-  padding-block: var(--space-16);
+  padding-block: var(--space-14);
   align-items: start;
 }
 
@@ -33,20 +33,38 @@
 .guide__toc-group {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
 }
 
 .guide__toc-heading {
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  width: 100%;
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
   color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.guide__toc-heading:hover {
+  color: var(--color-primary);
+}
+
+.guide__toc-items {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
 }
 
 .guide__toc-item {
+  background: none;
+  border: none;
+  text-align: left;
   font-size: var(--text-sm);
   font-weight: var(--font-regular);
   color: var(--color-text-muted);
-  text-decoration: none;
   padding-left: var(--space-2);
   cursor: pointer;
 }
@@ -99,6 +117,8 @@
 @media (max-width: 768px) {
   .guide {
     grid-template-columns: 1fr;
+    padding-block: var(--space-8);
+    gap: var(--space-8);
   }
 
   .guide__sidebar {

--- a/client/resources/guides/detail/detail.css
+++ b/client/resources/guides/detail/detail.css
@@ -2,7 +2,7 @@
   display: grid;
   grid-template-columns: 250px 1fr;
   gap: var(--space-16);
-  padding-block: var(--space-14);
+  padding-block: var(--space-10);
   align-items: start;
 }
 
@@ -114,18 +114,26 @@
 }
 
 /* Responsiveness */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .guide {
     grid-template-columns: 1fr;
-    padding-block: var(--space-8);
-    gap: var(--space-8);
+    padding-block: var(--space-6);
+    gap: var(--space-6);
   }
 
   .guide__sidebar {
     position: static;
   }
 
+  .guide__toc {
+    display: none;
+  }
+
   .guide__content {
     max-width: 100%;
+  }
+
+  .guide__title {
+    font-size: var(--text-3xl);
   }
 }

--- a/client/resources/guides/detail/detail.css
+++ b/client/resources/guides/detail/detail.css
@@ -1,0 +1,111 @@
+.guide {
+  display: grid;
+  grid-template-columns: 250px 1fr;
+  gap: var(--space-16);
+  padding-block: var(--space-16);
+  align-items: start;
+}
+
+/* Sidebar */
+.guide__sidebar {
+  position: sticky;
+  top: var(--space-8);
+}
+
+.guide__back {
+  display: inline-block;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  margin-bottom: var(--space-6);
+}
+
+.guide__back:hover {
+  color: var(--color-text-primary);
+}
+
+.guide__toc {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.guide__toc-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.guide__toc-heading {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.guide__toc-item {
+  font-size: var(--text-sm);
+  font-weight: var(--font-regular);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  padding-left: var(--space-2);
+  cursor: pointer;
+}
+
+.guide__toc-item:hover {
+  color: var(--color-text-primary);
+}
+
+.guide__toc-item--active {
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.guide__toc-item--active::before {
+  content: "~ ";
+}
+
+/* Main content */
+.guide__content {
+  max-width: 680px;
+}
+
+.guide__title {
+  font-family: var(--font-serif);
+  font-size: var(--text-4xl);
+  font-weight: var(--font-regular);
+  color: var(--color-text-primary);
+  line-height: var(--leading-tight);
+  margin-bottom: var(--space-10);
+}
+
+.guide__section {
+  margin-bottom: var(--space-8);
+}
+
+.guide__section-heading {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-3);
+}
+
+.guide__section-body {
+  font-size: var(--text-base);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+/* Responsiveness */
+@media (max-width: 768px) {
+  .guide {
+    grid-template-columns: 1fr;
+  }
+
+  .guide__sidebar {
+    position: static;
+  }
+
+  .guide__content {
+    max-width: 100%;
+  }
+}

--- a/client/resources/guides/detail/detail.js
+++ b/client/resources/guides/detail/detail.js
@@ -1,0 +1,139 @@
+import "/shared/components/nav/nav.js";
+import "/shared/components/footer/footer.js";
+
+
+
+// Hardcoded guide data
+const guides = {
+  1: {
+    id: "1",
+    title: "Guide to understanding and improving business credit scores",
+    sections: [
+      {
+        heading: "Introduction",
+        items: ["What is a business credit score?", "Why your score matters"],
+      },
+      {
+        heading: "How scores work",
+        items: [
+          "How scores are calculated",
+          "Understanding your credit report",
+          "Score ranges explained",
+        ],
+      },
+      {
+        heading: "Improving your score",
+        items: [
+          "Register your business",
+          "Get a TIN",
+          "Start with small credit",
+          "Pay on time, every time",
+          "Manage credit utilisation",
+          "Monitor your report",
+        ],
+      },
+    ],
+    content: [
+      {
+        heading: "Introduction",
+        body: "If you've ever applied for a business loan and received a vague rejection with no clear reason, your business credit score may have played a role. Understanding what it is and how it works is the first step to taking control of it.",
+      },
+      {
+        heading: "The basic idea",
+        body: "A business credit score is a number that tells lenders, suppliers, and financial institutions how creditworthy your business is. In plain terms: how likely you are to repay money you borrow. The higher the number, the more confidence the financial system has in your business. Think of it as your business's financial reputation, built quietly in the background every time you take on credit and either honour or miss a repayment.",
+      },
+      {
+        heading: "It's attached to your business, not you personally",
+        body: "This is one of the most important distinctions to understand. A business credit score belongs to your registered business entity, not to you as an individual. You already have a personal credit score tied to your name and identity. Your business, once registered, builds its own separate score. Why does this matter? Because keeping the two separate protects your personal finances from your business obligations and vice versa. If your business takes on debt, a well-maintained separation means your personal financial standing is not automatically at risk.",
+      },
+      {
+        heading: "Who tracks and reports it in Nigeria",
+        body: "In Nigeria, business credit data is collected and maintained by licensed credit bureaus. These organisations gather information from banks, microfinance institutions, fintechs, and other lenders, then compile it into a credit report and score for your business. The three primary bureaus operating in Nigeria are CRC Credit Bureau, Credit Registry, and FirstCentral Credit Bureau. Each uses its own scoring model, which means your score may vary slightly depending on which bureau a lender consults but the underlying data feeding into each score is largely the same.",
+      },
+      {
+        heading: "How a score is different from a credit report",
+        body: "These two terms are often used interchangeably, but they are not the same thing. Your credit report is the full record, every account, every payment, every inquiry, every public filing attached to your business. Your credit score is a single number calculated from that report, designed to give lenders a quick summary of what the report contains. You need both. The score gets you through the door; the report tells the full story once a lender decides to look closer.",
+      },
+    ],
+  },
+};
+
+// Read guideId from URL
+const params = new URLSearchParams(window.location.search);
+const guideId = params.get("guideId");
+
+console.log("guideId:", guideId);
+
+const guide = guides[guideId];
+
+
+
+// Get DOM elements
+const guideTitle = document.getElementById("guide-title");
+const guideBody = document.getElementById("guide-body");
+const tocRoot = document.getElementById("toc-root");
+
+// Handle missing or invalid guideId
+if (!guide) {
+  guideTitle.textContent = "Guide not found";
+  guideBody.innerHTML = `
+    <p>The guide you are looking for does not exist or the link may be broken.</p>
+    <a href="/resources/">Go back to resources</a>
+  `;
+} else {
+  // Render title
+  guideTitle.textContent = guide.title;
+
+  // Render table of contents
+  guide.sections.forEach((section) => {
+    const group = document.createElement("div");
+    group.className = "guide__toc-group";
+
+    const heading = document.createElement("p");
+    heading.className = "guide__toc-heading";
+    heading.textContent = section.heading;
+    group.appendChild(heading);
+
+    section.items.forEach((item, index) => {
+      const link = document.createElement("span");
+      link.className = "guide__toc-item";
+      link.textContent = item;
+
+      // Set first item of first section as active by default
+      if (section === guide.sections[0] && index === 0) {
+        link.classList.add("guide__toc-item--active");
+      }
+
+      group.appendChild(link);
+    });
+
+    tocRoot.appendChild(group);
+  });
+
+  // Render content
+  guide.content.forEach((section) => {
+    const div = document.createElement("div");
+    div.className = "guide__section";
+
+    const heading = document.createElement("h2");
+    heading.className = "guide__section-heading";
+    heading.textContent = section.heading;
+
+    const body = document.createElement("p");
+    body.className = "guide__section-body";
+    body.textContent = section.body;
+
+    div.appendChild(heading);
+    div.appendChild(body);
+    guideBody.appendChild(div);
+  });
+
+  // TOC click handlers
+  const tocItems = document.querySelectorAll(".guide__toc-item");
+  tocItems.forEach((item) => {
+    item.addEventListener("click", () => {
+      tocItems.forEach((i) => i.classList.remove("guide__toc-item--active"));
+      item.classList.add("guide__toc-item--active");
+    });
+  });
+}

--- a/client/resources/guides/detail/detail.js
+++ b/client/resources/guides/detail/detail.js
@@ -1,8 +1,6 @@
 import "/shared/components/nav/nav.js";
 import "/shared/components/footer/footer.js";
 
-
-
 // Hardcoded guide data
 const guides = {
   1: {
@@ -61,12 +59,7 @@ const guides = {
 // Read guideId from URL
 const params = new URLSearchParams(window.location.search);
 const guideId = params.get("guideId");
-
-console.log("guideId:", guideId);
-
 const guide = guides[guideId];
-
-
 
 // Get DOM elements
 const guideTitle = document.getElementById("guide-title");
@@ -78,7 +71,6 @@ if (!guide) {
   guideTitle.textContent = "Guide not found";
   guideBody.innerHTML = `
     <p>The guide you are looking for does not exist or the link may be broken.</p>
-    <a href="/resources/">Go back to resources</a>
   `;
 } else {
   // Render title
@@ -89,24 +81,42 @@ if (!guide) {
     const group = document.createElement("div");
     group.className = "guide__toc-group";
 
-    const heading = document.createElement("p");
-    heading.className = "guide__toc-heading";
-    heading.textContent = section.heading;
-    group.appendChild(heading);
+    const headingBtn = document.createElement("button");
+    headingBtn.className = "guide__toc-heading";
+    headingBtn.textContent = section.heading;
+    headingBtn.setAttribute("aria-expanded", "true");
+    group.appendChild(headingBtn);
+
+    const itemList = document.createElement("div");
+    itemList.className = "guide__toc-items";
 
     section.items.forEach((item, index) => {
-      const link = document.createElement("span");
-      link.className = "guide__toc-item";
-      link.textContent = item;
+      const btn = document.createElement("button");
+      btn.className = "guide__toc-item";
+      btn.textContent = item;
 
-      // Set first item of first section as active by default
       if (section === guide.sections[0] && index === 0) {
-        link.classList.add("guide__toc-item--active");
+        btn.classList.add("guide__toc-item--active");
       }
 
-      group.appendChild(link);
+      btn.addEventListener("click", () => {
+        document
+          .querySelectorAll(".guide__toc-item")
+          .forEach((i) => i.classList.remove("guide__toc-item--active"));
+        btn.classList.add("guide__toc-item--active");
+      });
+
+      itemList.appendChild(btn);
     });
 
+    // Toggle collapse on heading click
+    headingBtn.addEventListener("click", () => {
+      const isExpanded = headingBtn.getAttribute("aria-expanded") === "true";
+      headingBtn.setAttribute("aria-expanded", String(!isExpanded));
+      itemList.style.display = isExpanded ? "none" : "flex";
+    });
+
+    group.appendChild(itemList);
     tocRoot.appendChild(group);
   });
 

--- a/client/resources/guides/detail/index.html
+++ b/client/resources/guides/detail/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=DM+Serif+Text:ital@0;1&family=Urbanist:wght@300;400;500;600;700;800&display=swap"
+    />
+    <link rel="stylesheet" href="/shared/base/main.css" />
+    <link rel="stylesheet" href="detail.css" />
+    <title>Ekehi — Guide Details</title>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav id="nav-root" class="nav" aria-label="Main navigation"></nav>
+    </header>
+
+    <main class="container">
+      <!-- Left Sidebar -->
+      <div class="guide">
+        <aside class="guide__sidebar">
+          <a href="/resources/" class="guide__back">← Go back</a>
+          <nav class="guide__toc" aria-label="Table of contents">
+            <div id="toc-root"></div>
+          </nav>
+        </aside>
+
+        <!-- Main Content -->
+        <article class="guide__content">
+          <h1 class="guide__title" id="guide-title"></h1>
+          <div class="guide__body" id="guide-body"></div>
+        </article>
+      </div>
+    </main>
+
+    <footer id="footer-root" class="footer"></footer>
+    <script type="module" src="detail.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
<!-- Describe what this PR does and why -->
The page renders a single guide's full content from hardcoded dummy data keyed by guideId. It includes a left sidebar with a Go back link and a collapsible table of contents, and a main content area with the guide title and all content sections. Navigation arrives via URL query parameter ?guideId=<id>. A friendly error state is shown for missing or invalid guideIds.

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Linked Issue
Closes #118 

## ClickUp Task (if applicable)
Link:

## Changes Made
- Created client/resources/guides/detail/index.html
- Created client/resources/guides/detail/detail.js
- Created client/resources/guides/detail/detail.css
- Reads guideId from URLSearchParams to identify which guide to render
- Renders guide title, table of contents, and all content sections from hardcoded data
- TOC items are clickable and highlight the active item
- Go back link navigates to the resources page
- Friendly error state for missing or invalid guideId
- Responsive layout with sidebar stacking above content on mobile
- Page uses shared nav and footer components

## Screenshots (for UI changes)
<img width="1915" height="914" alt="Screenshot 2026-03-25 195839" src="https://github.com/user-attachments/assets/5382f5d8-0d15-453e-a89a-67bbafb5eac4" />
<img width="1895" height="914" alt="Screenshot 2026-03-25 195858" src="https://github.com/user-attachments/assets/41952545-d052-4fc9-bd8e-695ae98557df" />

mobile view look
<img width="633" height="894" alt="Screenshot 2026-03-26 113204" src="https://github.com/user-attachments/assets/9195b9e2-268f-43c4-96a2-156cc7ac9c16" />
<img width="633" height="888" alt="Screenshot 2026-03-26 113220" src="https://github.com/user-attachments/assets/c6fc8d2f-569e-472a-9b31-55381b454b32" />


## Checklist
- [x] Branch is up to date with `development`
- [x] Code follows project conventions
- [x] No `.env` or secrets committed
- [x] UI changes tested on mobile and desktop
- [ ] Backend changes tested locally
- [x] PR is linked to an issue or ClickUp task
