### PR TITLE
[frontend] feat: add Guides section to resources page

### DIFF
--- a/client/resources/index.html
+++ b/client/resources/index.html
@@ -19,7 +19,6 @@
     </header>
 
     <main class="container flex flex-col gap-8">
-      
       <section class="container__hero flex flex-col gap-2 text-center">
         <h1 class="container__hero--title">Training &amp; Resources Library</h1>
         <p class="container__hero--description">
@@ -40,6 +39,10 @@
 
       <section class="results-section">
         <div id="trainings-list"></div>
+      </section>
+
+      <section class="guides-section">
+        <div id="guides-list"></div>
       </section>
     </main>
 

--- a/client/resources/resources.css
+++ b/client/resources/resources.css
@@ -29,6 +29,20 @@
   color: var(--color-primary-hover);
 }
 
+.view-all-link--outlined {
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.view-all-link--outlined:hover {
+  background-color: var(--color-primary);
+  color: var(--color-white);
+}
+
 .trainings-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -42,7 +56,6 @@
   aspect-ratio: 352 / 226;
   padding: var(--space-3);
   margin: 0;
-
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: var(--space-3);
@@ -127,15 +140,62 @@
   color: #c0392b;
 }
 
+/* ── Guides section ─────────────────────────────────── */
+.guides-section {
+  padding-bottom: var(--space-16);
+}
+
+.guides-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-6);
+}
+
+.guide-card__cover {
+  width: 100%;
+  margin: 0;
+  border-radius: var(--radius-2xl);
+  overflow: hidden;
+  aspect-ratio: 352 / 226;
+}
+
+.guide-card__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.guide-card__title {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  line-height: var(--leading-snug);
+}
+
+.guide-card__excerpt {
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  line-height: var(--leading-normal);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* ── Responsive ─────────────────────────────────────── */
 @media (max-width: 900px) {
-  .trainings-grid {
+  .trainings-grid,
+  .guides-grid {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
 @media (max-width: 600px) {
-  .trainings-grid {
+  .trainings-grid,
+  .guides-grid {
     grid-template-columns: 1fr;
   }
 

--- a/client/resources/resources.js
+++ b/client/resources/resources.js
@@ -132,5 +132,82 @@ async function loadTrainings() {
   }
 }
 
+// ── Guides ───────────────────────────────────────────
+
+const GUIDES_PLACEHOLDER = [
+  {
+    id: "1",
+    title: "Guide to understanding and improving business credit scores",
+    excerpt:
+      "Unlock your business's full potential by improving your credit score. Check out our guide for expert tips.",
+    cover_image: null,
+  },
+  {
+    id: "2",
+    title: "CAC registration guide for Nigeria",
+    excerpt:
+      "Learn how to register your business with the Corporate Affairs Commission. Read our guide for expert tips.",
+    cover_image: null,
+  },
+  {
+    id: "3",
+    title: "Women's Empowerment Training Guide: A Step-by-Step Approach",
+    excerpt:
+      "Ready to elevate your business? Read our Women's Empowerment Training Guide for actionable strategies.",
+    cover_image: null,
+  },
+];
+
+function renderGuideCard(guide) {
+  const card = document.createElement("div");
+  card.className = "guide-card | flex flex-col gap-3";
+
+  const imageSrc =
+    guide.cover_image ?? "/assets/images/black-woman-wearing-glasses.png";
+
+  card.innerHTML = `
+    <figure class="guide-card__cover">
+      <img
+        src="${imageSrc}"
+        alt="${guide.title}"
+        class="guide-card__image"
+      />
+    </figure>
+    <div class="guide-card__body | flex flex-col gap-2">
+      <h3 class="guide-card__title">${guide.title}</h3>
+      <p class="guide-card__excerpt">${guide.excerpt}</p>
+    </div>
+  `;
+
+  return card;
+}
+
+function initGuidesHeader() {
+  if (document.getElementById("guides-heading")) return;
+  const header = document.createElement("div");
+  header.className = "results-header";
+  header.innerHTML = `
+    <h2 id="guides-heading">Guides</h2>
+    <a href="#" class="view-all-link view-all-link--outlined">View all guides</a>
+  `;
+  document.querySelector(".guides-section").prepend(header);
+}
+
+function loadGuides() {
+  // When a guides API is available, replace the body of this function with:
+  // const res = await api.get('/guides');
+  // const guides = res.data ?? [];
+
+  const guides = GUIDES_PLACEHOLDER;
+  const guidesList = document.getElementById("guides-list");
+  guidesList.className = "guides-grid";
+
+  guidesList.innerHTML = "";
+  guides.forEach((guide) => guidesList.appendChild(renderGuideCard(guide)));
+}
+
 initTrainingsHeader();
 loadTrainings();
+
+initGuidesHeader();
+loadGuides();


### PR DESCRIPTION
## Summary

Adds a Guides section to the resources page, rendered below the existing Training & Events section. The section displays a header with a "View all guides" outlined button and a responsive 3-column grid of guide cards, each showing a cover image, title, and excerpt.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Linked Issue

Closes #116 

## Changes Made

- `client/resources/index.html`: Added `<section class="guides-section">` with `<div id="guides-list">` below the existing `.results-section`
- `client/resources/resources.js`: Added `GUIDES_PLACEHOLDER` data, `renderGuideCard()`, `initGuidesHeader()`, and `loadGuides()`, — structured to make future API swap-in straightforward
- `client/resources/resources.css`: Added `.view-all-link--outlined` modifier, `.guides-section`, `.guides-grid`, and guide card styles; extended existing responsive breakpoints to cover the guides grid