### PR TITLE
[frontend] feat: add Templates section to resources page

### DIFF
--- a/client/resources/index.html
+++ b/client/resources/index.html
@@ -38,6 +38,22 @@
         ></div>
       </section>
 
+ 
+     <section class="templates">
+        <div class="templates__header flex justify-between items-center mb-auto">
+          <h2 class="font-sans text-2xl text-primary font-bold">Templates</h2>
+          <button class="templates__header--btn px-4 py-2 rounded-md text-sm text-muted font-sans">
+            View all templates
+          </button>
+        </div>
+  
+        <div id="templates-grid" class="flex flex-wrap justify-between">
+          <!-- Rendered by loadTemplates() -->
+        </div>
+</section>
+
+
+
       <section class="results-section">
         <div id="trainings-list"></div>
       </section>

--- a/client/resources/resources.css
+++ b/client/resources/resources.css
@@ -145,3 +145,110 @@
     gap: var(--space-2);
   }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+.templates__header{margin-bottom: 10px;}
+.templates__header--btn{border:1px solid var(--color-border);}
+
+/* Container card with the visible border-radius outline */
+.template-card {
+  width: 100%;
+  max-width: 360px;
+  background: var(--color-white);
+  border: 1px solid var(--color-neutral-300);
+  border-radius: var(--radius-2xl); 
+  overflow: hidden;
+}
+
+/* Header visual area with the background guide cards */
+.template-card__visual {
+  height: 180px;
+  background-color: var(--color-white);
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* The larger, grey-lined background "guide" card */
+.template-card__visual::before {
+  content: "";
+  position: absolute;
+  left: 50px;
+  width: 160px;
+  height: 220px;
+  background: var(--color-white);
+  border: 1px solid var(--color-neutral-300);
+  border-radius: var(--radius-sm);
+  transform: rotate(-14deg);
+  opacity: 0.8;
+  background-image: repeating-linear-gradient(
+    0deg,
+    var(--color-neutral-300),
+    var(--color-neutral-100) 8px,
+    transparent 8px,
+    transparent 20px
+  );
+  background-position: center 20px;
+}
+
+/* The tilted colored template mockup */
+.template-card__mockup {
+  position: absolute;
+  bottom: -20px;
+  right: 100px;
+  width: 140px;
+  height: 140px;
+  border-radius: var(--radius-sm);
+  transform: rotate(16.533deg);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 2;
+}
+
+.mockup-header {
+  padding: var(--space-3);
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: var(--font-semibold);
+  line-height: 1.2;
+}
+
+.mockup-img {
+  /* flex-grow: 1;  */
+  background-size: 220px;
+  background-position: center;
+  background-color: var(--color-neutral-200);
+}
+
+/* Content Area */
+.template-card__content {
+  padding: var(--space-6);
+}
+
+
+/* read more link */
+.template-card__link {
+  color: var(--color-purple-600); 
+  font-weight: var(--font-bold);
+  font-size: var(--text-sm);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}

--- a/client/resources/resources.js
+++ b/client/resources/resources.js
@@ -60,6 +60,11 @@ const CARD_COLORS = {
   mentorship_programme: { bg: "#fce7f3", panel: "#f472b6", text: "#831843" },
 };
 
+
+
+
+
+
 function renderDateMeta(deadline) {
   if (!deadline) return "";
   return `<span class="training-card__date">
@@ -134,3 +139,57 @@ async function loadTrainings() {
 
 initTrainingsHeader();
 loadTrainings();
+
+
+
+
+
+const templateData = [
+  {
+    id: "1",
+    title: "Basic financial management template",
+    excerpt: "Explore our Basic Financial Management Template designed specifically for small and medium enterprises! It's an excellent resource to get you ready for global opportunities.",
+    color: "#4ecdc4", 
+    cover_image: null
+  },
+  {
+    id: "2",
+    title: "Tax basics for Nigerian SMEs",
+    excerpt: "Explore our template on Tax Basics for Nigerian SMEs. It's an essential resource to help you navigate the complexities of taxation and ensure your business is ready for success.",
+    color: "#e91e8c", 
+    cover_image: null
+  },
+  {
+    id: "3",
+    title: "Export readiness checklist for SMEs",
+    excerpt: "Check out our template for the Export Readiness Checklist tailored for SMEs! It's a great tool to help you prepare for international markets.",
+    color: "#4caf50",
+    cover_image: null
+  }
+];
+
+function loadTemplates() {
+  const grid = document.getElementById('templates-grid');
+  if (!grid) return;
+
+  grid.innerHTML = templateData.map(item => `
+    <article class="template-card flex flex-col shadow-sm">
+      <div class="template-card__visual">
+        <div class="template-card__mockup" style="background-color:${item.color}">
+          <div class="mockup-header">${item.title}</div>
+          <div class="mockup-img">${item.cover_image}</div>
+        </div>
+      </div>
+      
+      <div class="template-card__content flex flex-col flex-1">
+        <h3 class="font-sans text-lg text-primary mb-3 font-semibold py-2">${item.title}</h3>
+        <p class="text-xs text-secondary leading-relaxed mb-6">${item.excerpt}</p>
+        <a href="#" class="template-card__link mt-auto">
+          Read more <span>→</span>
+        </a>
+      </div>
+    </article>
+  `).join('');
+}
+
+document.addEventListener('DOMContentLoaded', loadTemplates);

--- a/client/resources/resources.js
+++ b/client/resources/resources.js
@@ -177,7 +177,7 @@ function loadTemplates() {
       <div class="template-card__visual">
         <div class="template-card__mockup" style="background-color:${item.color}">
           <div class="mockup-header">${item.title}</div>
-          <div class="mockup-img">${item.cover_image}</div>
+          <div class="mockup-img"></div>
         </div>
       </div>
       


### PR DESCRIPTION
## Summary
<img width="1644" height="615" alt="Screenshot 2026-03-25 230647" src="https://github.com/user-attachments/assets/19d18be0-870c-47de-91d0-4fed3a93bd95" />

Added a Templates section to the resources page (client/resources/), Shows a 3-column card grid of downloadable business templates with a "View all templates" link.


## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Linked Issue
Closes #117

## ClickUp Task (if applicable)
Link:





## Checklist
- [x] Branch is up to date with `development`
- [x] Code follows project conventions
- [x] No `.env` or secrets committed
- [x] UI changes tested on mobile and desktop
- [ ] Backend changes tested locally
- [x] PR is linked to an issue or ClickUp task
