### PR TITLE
[frontend] fix: wrap filters dropdown on training page

### DIFF
--- a/client/resources/index.html
+++ b/client/resources/index.html
@@ -33,11 +33,11 @@
         </div>
         <div
           id="filter-dropdowns"
-          class="filter__section--dropdowns flex gap-4"
+          class="filter__section--dropdowns flex flex-wrap gap-4"
         ></div>
       </section>
 
- 
+
      <section class="templates">
         <div class="templates__header flex justify-between items-center mb-auto">
           <h2 class="font-sans text-2xl text-primary font-bold">Templates</h2>
@@ -45,7 +45,7 @@
             View all templates
           </button>
         </div>
-  
+
         <div id="templates-grid" class="flex flex-wrap justify-between">
           <!-- Rendered by loadTemplates() -->
         </div>


### PR DESCRIPTION
## Summary
Fixed overflowing content on training resources page

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Linked Issue
Closes #122 


## Changes Made
- added flex-wrap to filter dropdown


## Checklist
- [x] Branch is up to date with `development`
- [x] Code follows project conventions
- [x] No `.env` or secrets committed
- [x] UI changes tested on mobile and desktop
- [ ] Backend changes tested locally
- [x] PR is linked to an issue or ClickUp task
