### PR TITLE
feat: add training detail page

### DIFF
--- a/client/resources/training/detail/detail.css
+++ b/client/resources/training/detail/detail.css
@@ -1,0 +1,274 @@
+/* ==========================================================================
+   Training Detail Page — detail.css
+   ========================================================================== */
+
+/* ── detail-page ─────────────────────────────────────── */
+.detail-page {
+  max-width: var(--container-max);
+  margin-inline: auto;
+  padding-inline: var(--space-8);
+  padding-block: var(--space-12);
+}
+
+/* ── Loading / error states ──────────────────────────── */
+.detail-page__state {
+  text-align: center;
+  padding-block: var(--space-20);
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  color: var(--color-text-muted);
+}
+
+.detail-page__back-link {
+  display: inline-block;
+  margin-top: var(--space-4);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+/* ── Breadcrumb ──────────────────────────────────────── */
+.detail-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-8);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+}
+
+.detail-breadcrumb__link {
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: color 150ms ease;
+}
+
+.detail-breadcrumb__link:hover {
+  color: var(--color-primary);
+}
+
+.detail-breadcrumb__sep {
+  color: var(--color-text-muted);
+}
+
+.detail-breadcrumb__current {
+  color: var(--color-text-secondary);
+  font-weight: var(--font-medium);
+}
+
+/* ── Shared two-column grid ──────────────────────────── */
+/*
+   Both the hero and the body use the exact same column definition
+   so that left text and right card/sidebar share the same edges.
+*/
+.detail-hero,
+.detail-body {
+  display: grid;
+  grid-template-columns: 55fr 45fr;
+  gap: var(--space-10);
+}
+
+/* ── detail-hero ─────────────────────────────────────── */
+.detail-hero {
+  align-items: center;
+  margin-bottom: var(--space-12);
+}
+
+.detail-hero__info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  min-width: 0;
+}
+
+.detail-hero__datetime {
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  font-weight: var(--font-regular);
+}
+
+.detail-hero__title {
+  font-family: var(--font-serif);
+  font-size: var(--text-4xl);
+  font-weight: var(--font-regular);
+  color: var(--color-text-primary);
+  line-height: var(--leading-tight);
+  margin: 0;
+}
+
+/* Button — small rounded rectangle, not a pill */
+.detail-hero__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2) var(--space-5);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-on-primary);
+  background-color: var(--color-purple-800);
+  
+  text-decoration: none;
+  align-self: flex-start;
+  transition: background-color 150ms ease;
+}
+
+.detail-hero__cta:hover {
+  background-color: var(--color-purple-700);
+}
+
+/* ── Cover card ──────────────────────────────────────── */
+.detail-hero__cover {
+  display: grid;
+  grid-template-columns: 60fr 40fr;
+  border-radius: var(--radius-2xl);
+  overflow: hidden;
+  height: 260px;
+  min-width: 0;
+}
+
+.detail-hero__cover-panel {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: var(--space-5);
+  height: 100%;
+}
+
+.detail-hero__cover-type {
+  font-family: var(--font-sans);
+  font-size: var(--text-xl);
+  font-weight: var(--font-semibold);
+  line-height: var(--leading-snug);
+}
+
+.detail-hero__cover-host {
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+}
+
+.detail-hero__cover-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center top;
+  display: block;
+}
+
+/* ── detail-body ─────────────────────────────────────── */
+.detail-body {
+  align-items: start;
+}
+
+.detail-body__main {
+  min-width: 0;
+}
+
+.detail-body__section-title {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-4);
+}
+
+.detail-body__description {
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+  white-space: pre-line;
+}
+
+/* ── detail-sidebar ──────────────────────────────────── */
+.detail-sidebar {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2xl);
+  padding: var(--space-6);
+  min-width: 0;
+}
+
+.detail-sidebar__title {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-5);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.detail-sidebar__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.detail-sidebar__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.detail-sidebar__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.detail-sidebar__value {
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+/* ── training-card cursor ────────────────────────────── */
+.training-card {
+  cursor: pointer;
+}
+
+/* ── Responsive ──────────────────────────────────────── */
+@media (max-width: 900px) {
+  .detail-hero,
+  .detail-body {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-hero__cover {
+    height: 220px;
+  }
+
+  .detail-sidebar {
+    order: -1;
+  }
+}
+
+@media (max-width: 600px) {
+  .detail-page {
+    padding-inline: var(--space-5);
+    padding-block: var(--space-8);
+  }
+
+  .detail-hero__title {
+    font-size: var(--text-3xl);
+  }
+
+  .detail-hero__cover {
+    height: 180px;
+  }
+
+  .detail-hero__cover-type {
+    font-size: var(--text-lg);
+  }
+}

--- a/client/resources/training/detail/detail.js
+++ b/client/resources/training/detail/detail.js
@@ -1,0 +1,147 @@
+import api from "/shared/services/api.js";
+import "/shared/components/nav/nav.js";
+import "/shared/components/footer/footer.js";
+import {
+  formatDate,
+  daysUntil,
+  humanize,
+} from "/shared/utils/opportunity.utils.js";
+import EKEHI_ENUMS from "/shared/constants/enums.js";
+
+
+// ── State helpers ──────────────────────────────────────
+function showLoading() {
+  document.getElementById("detail-loading").hidden = false;
+  document.getElementById("detail-error").hidden   = true;
+  document.getElementById("detail-content").hidden = true;
+}
+
+function showError(message) {
+  document.getElementById("detail-loading").hidden            = true;
+  document.getElementById("detail-error").hidden              = false;
+  document.getElementById("detail-content").hidden            = true;
+  document.getElementById("detail-error-message").textContent = message;
+}
+
+function showContent() {
+  document.getElementById("detail-loading").hidden = true;
+  document.getElementById("detail-error").hidden   = true;
+  document.getElementById("detail-content").hidden = false;
+}
+
+// ── Helpers ────────────────────────────────────────────
+function formatLabel(value) {
+  const map = {
+    online:    "Virtual event",
+    in_person: "In-person event",
+    hybrid:    "Hybrid event",
+  };
+  return map[value] ?? humanize(value) ?? "—";
+}
+
+// ── Render ─────────────────────────────────────────────
+function render(programme) {
+  const deadline = programme.application_deadline;
+
+  const typeLabel =
+    EKEHI_ENUMS.programmeType[programme.programme_type] ??
+    humanize(programme.programme_type);
+
+  const locationLabel =
+    EKEHI_ENUMS.locationScope[programme.location_scope] ??
+    programme.location_scope ??
+    "—";
+
+  document.getElementById("detail-datetime").textContent =
+    deadline ? formatDate(deadline) : "Date TBC";
+
+  document.getElementById("detail-title").textContent =
+    programme.programme_name || "Untitled programme";
+
+  const cta = document.getElementById("detail-cta");
+  if (programme.apply_url) {
+    cta.href = programme.apply_url;
+    cta.style.display = "inline-block";
+  } else {
+    cta.style.display = "none";
+  }
+
+  // Cover panel
+  const typeEl = document.getElementById("detail-type");
+  const hostEl = document.getElementById("detail-host");
+  if (typeEl) typeEl.textContent = typeLabel || "Training";
+  if (hostEl) hostEl.textContent = programme.provider || "";
+
+  document.getElementById("detail-description").textContent =
+    programme.description || "No description available.";
+
+  document.getElementById("sidebar-format-value").textContent =
+    formatLabel(programme.format);
+
+  document.getElementById("sidebar-deadline-value").textContent =
+    deadline ? daysUntil(deadline) : "Date TBC";
+
+  document.getElementById("sidebar-language-value").textContent = "English";
+
+  document.getElementById("sidebar-provider-value").textContent =
+    programme.provider || "—";
+
+  const locationEl = document.getElementById("sidebar-location-value");
+  if (locationEl) locationEl.textContent = locationLabel;
+
+  document.title = `${programme.programme_name} — Ekehi`;
+
+  showContent();
+
+  const breadcrumb = document.getElementById("detail-breadcrumb-title");
+  if (breadcrumb) breadcrumb.textContent = programme.programme_name;
+
+  // Colour the cover panel to match the card colours
+const CARD_COLORS = {
+  accelerator:          { bg: "#F9E6FF", text: "#581c87" },
+  bootcamp:             { bg: "#ffedd5", text: "#7c2d12" },
+  workshop:             { bg: "#DEF6EB", text: "#033F25" },
+  online_course:        { bg: "#dbeafe", text: "#1e3a8a" },
+  mentorship_programme: { bg: "#fce7f3", text: "#831843" },
+};
+
+const colors = CARD_COLORS[programme.programme_type] ?? CARD_COLORS.accelerator;
+const panel = document.getElementById("detail-cover-panel");
+if (panel) {
+  panel.style.backgroundColor = colors.bg;
+  panel.style.color = colors.text;
+}
+
+}
+
+// ── Fetch ──────────────────────────────────────────────
+async function loadTraining() {
+  showLoading();
+
+  const params = new URLSearchParams(window.location.search);
+  const id = params.get("id");
+
+  if (!id) {
+    showError("No training programme specified.");
+    return;
+  }
+
+  try {
+    const res = await api.get(`/trainings/${id}`);
+
+    if (!res?.data) {
+      showError("Training programme not found.");
+      return;
+    }
+
+    render(res.data);
+  } catch (err) {
+    if (err?.status === 404) {
+      showError("This training programme could not be found.");
+    } else {
+      showError(err.message || "Something went wrong. Please try again.");
+    }
+  }
+}
+
+loadTraining();

--- a/client/resources/training/detail/index.html
+++ b/client/resources/training/detail/index.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=DM+Serif+Text:ital@0;1&family=Urbanist:wght@300;400;500;600;700;800&display=swap"
+    />
+    <link rel="stylesheet" href="/shared/base/main.css" />
+    <link rel="stylesheet" href="detail.css" />
+    <title>Trainings and Events — Ekehi</title>
+  </head>
+  <body>
+
+    <header class="site-header">
+      <nav id="nav-root" class="nav" aria-label="Main navigation"></nav>
+    </header>
+
+    <main class="detail-page" id="detail-root">
+
+      <!-- Loading state -->
+      <div id="detail-loading" class="detail-page__state">
+        <p>Loading...</p>
+      </div>
+
+      <!-- Error state -->
+      <div id="detail-error" class="detail-page__state" hidden>
+        <p id="detail-error-message">Something went wrong. Please try again.</p>
+        <a href="../index.html" class="detail-page__back-link">Back to Training &amp; Resources</a>
+      </div>
+
+      <!-- Content — populated by JS -->
+      <div id="detail-content" hidden>
+        <!-- Breadcrumb -->
+        <nav class="detail-breadcrumb" aria-label="Breadcrumb">
+          <a href="/resources/training/" class="detail-breadcrumb__link">Resources</a>
+          <span class="detail-breadcrumb__sep" aria-hidden="true">›</span>
+          <span id="detail-breadcrumb-title" class="detail-breadcrumb__current"></span>
+        </nav>
+
+        <!-- Hero -->
+        <section class="detail-hero">
+
+          <!-- Left: info -->
+          <div class="detail-hero__info">
+            <p id="detail-datetime" class="detail-hero__datetime"></p>
+            <h1 id="detail-title" class="detail-hero__title"></h1>
+            <a id="detail-cta" href="#" class="detail-hero__cta" target="_blank" rel="noopener noreferrer">
+              Register now
+            </a>
+          </div>
+
+          <!-- Right: cover card — matches training card style -->
+          <div class="detail-hero__cover">
+            <div class="detail-hero__cover-panel" id="detail-cover-panel">
+              <span id="detail-type" class="detail-hero__cover-type"></span>
+              <span id="detail-host" class="detail-hero__cover-host"></span>
+            </div>
+            <img
+              src="/assets/images/black-woman-wearing-glasses.png"
+              class="detail-hero__cover-image"
+              alt="Training cover"
+            />
+          </div>
+
+        </section>
+
+        <!-- Body -->
+        <section class="detail-body">
+
+          <!-- Left: about -->
+          <div class="detail-body__main">
+            <h2 class="detail-body__section-title">About this event</h2>
+            <p id="detail-description" class="detail-body__description"></p>
+          </div>
+
+          <!-- Right: sidebar -->
+          <aside class="detail-sidebar" aria-label="Event details">
+            <h2 class="detail-sidebar__title">Event Details</h2>
+            <ul class="detail-sidebar__list" role="list">
+              <li class="detail-sidebar__item">
+                <span class="detail-sidebar__icon" aria-hidden="true">
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.2"/>
+                    <path d="M5.5 8a2.5 2.5 0 1 0 5 0 2.5 2.5 0 0 0-5 0Z" stroke="currentColor" stroke-width="1.2"/>
+                  </svg>
+                </span>
+                <span class="detail-sidebar__value" id="sidebar-format-value"></span>
+              </li>
+              <li class="detail-sidebar__item">
+                <span class="detail-sidebar__icon" aria-hidden="true">
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <rect x="2" y="3.5" width="12" height="11" rx="1.5" stroke="currentColor" stroke-width="1.2"/>
+                    <path d="M5 2v3M11 2v3M2 7h12" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+                  </svg>
+                </span>
+                <span class="detail-sidebar__value" id="sidebar-deadline-value"></span>
+              </li>
+              <li class="detail-sidebar__item">
+                <span class="detail-sidebar__icon" aria-hidden="true">
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M8 2a6 6 0 1 0 0 12A6 6 0 0 0 8 2Z" stroke="currentColor" stroke-width="1.2"/>
+                    <path d="M2 8h12M8 2c-1.5 2-2 4-2 6s.5 4 2 6M8 2c1.5 2 2 4 2 6s-.5 4-2 6" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+                  </svg>
+                </span>
+                <span class="detail-sidebar__value" id="sidebar-language-value">English</span>
+              </li>
+              <li class="detail-sidebar__item">
+                <span class="detail-sidebar__icon" aria-hidden="true">
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <circle cx="8" cy="5" r="2.5" stroke="currentColor" stroke-width="1.2"/>
+                    <path d="M2.5 13c0-2.485 2.462-4.5 5.5-4.5s5.5 2.015 5.5 4.5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+                  </svg>
+                </span>
+                <span class="detail-sidebar__value" id="sidebar-provider-value"></span>
+              </li>
+            </ul>
+          </aside>
+
+        </section>
+
+      </div>
+
+    </main>
+
+    <footer id="footer-root" class="footer"></footer>
+
+    <script type="module" src="detail.js"></script>
+
+  </body>
+</html>


### PR DESCRIPTION
## Summary
Adds the Training Detail page for the Resources section. When a training card is clicked on the Training & Events list, it navigates to a detail page that fetches and displays the full programme data from the API.

## Type of Change
- [x] Feature

## Linked Issue
Closes #115 

## ClickUp Task (if applicable)
Link:

## Changes Made
- Added `resources/training/detail/index.html` — semantic HTML structure for the detail page
- Added `resources/training/detail/detail.css` — styles for hero, cover card, body, sidebar and breadcrumb
- Updated `resources/training/detail.js` — added click handler on cards to navigate to detail page with `?id=` query param

## Screenshots (for UI changes)
<!-- Add before/after screenshots or a screen recording -->

## Checklist
- [ ] Branch is up to date with `development`
- [x] Code follows project conventions
- [x] No `.env` or secrets committed
- [ ] UI changes tested on mobile and desktop
- [x] Backend changes tested locally
- [ ] PR is linked to an issue or ClickUp task