### PR TITLE
[frontend] feat(client): wire login and signup forms with auth mutations

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
-    "check": "pnpm lint && pnpm typecheck && pnpm format:check",
+    "check": "pnpm lint && pnpm typecheck && pnpm test && pnpm format:check",
     "fix": "pnpm lint:fix && pnpm format"
   },
   "dependencies": {

--- a/client/src/features/auth/components/login-form.test.tsx
+++ b/client/src/features/auth/components/login-form.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ApiError } from '#/lib/api'
+
+import { LoginForm } from './login-form'
+
+const mockMutateAsync = vi.fn()
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useSearch: () => ({ redirect: undefined }),
+}))
+
+vi.mock('../auth.query', () => ({
+  useLoginMutation: () => ({ mutateAsync: mockMutateAsync }),
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+function submitWith(email: string, password: string) {
+  const form = screen.getByRole('button', { name: /continue/i }).closest('form')
+  if (!form) throw new Error('form not found')
+
+  fireEvent.change(screen.getByPlaceholderText('Email address'), {
+    target: { value: email },
+  })
+  fireEvent.change(screen.getByPlaceholderText('Password'), {
+    target: { value: password },
+  })
+
+  fireEvent.submit(form)
+}
+
+describe('LoginForm', () => {
+  it('shows field errors and does not call the mutation on invalid input', async () => {
+    render(<LoginForm />)
+    submitWith('not-an-email', '')
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid email/i)).toBeTruthy()
+    })
+    expect(mockMutateAsync).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('calls the login mutation and navigates on valid input', async () => {
+    mockMutateAsync.mockResolvedValueOnce(undefined)
+    render(<LoginForm />)
+    submitWith('user@example.com', 'secret123')
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        password: 'secret123',
+      })
+    })
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/' })
+    })
+  })
+
+  it('surfaces the server error message when the mutation rejects', async () => {
+    mockMutateAsync.mockRejectedValueOnce(
+      new ApiError('Invalid credentials', 401),
+    )
+    render(<LoginForm />)
+    submitWith('user@example.com', 'wrongpass')
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toBe('Invalid credentials')
+    })
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+})

--- a/client/src/features/auth/components/login-form.tsx
+++ b/client/src/features/auth/components/login-form.tsx
@@ -1,0 +1,113 @@
+import { useNavigate, useSearch } from '@tanstack/react-router'
+import { useActionState } from 'react'
+import { z } from 'zod'
+
+import { Button } from '#/components/ui/button'
+import { Input } from '#/components/ui/input'
+import { PasswordInput } from '#/components/ui/password-input'
+import { isApiError } from '#/lib/api'
+
+import { useLoginMutation } from '../auth.query'
+import { loginRequestSchema } from '../auth.types'
+
+type LoginFormState = {
+  error?: string
+  fieldErrors?: { email?: string; password?: string }
+  values?: { email: string }
+}
+
+export function LoginForm() {
+  const navigate = useNavigate()
+  const { redirect } = useSearch({ strict: false })
+  const loginMutation = useLoginMutation()
+
+  async function loginAction(
+    _previousState: LoginFormState,
+    formData: FormData,
+  ): Promise<LoginFormState> {
+    const email = String(formData.get('email') ?? '')
+    const password = String(formData.get('password') ?? '')
+
+    const parsed = loginRequestSchema.safeParse({ email, password })
+    if (!parsed.success) {
+      const { fieldErrors } = z.flattenError(parsed.error)
+      return {
+        values: { email },
+        fieldErrors: {
+          email: fieldErrors.email?.[0],
+          password: fieldErrors.password?.[0],
+        },
+      }
+    }
+
+    try {
+      await loginMutation.mutateAsync(parsed.data)
+      await navigate({ to: redirect ?? '/' })
+      return {}
+    } catch (error) {
+      return {
+        values: { email },
+        error: isApiError(error)
+          ? error.message
+          : 'Unable to sign in. Please try again.',
+      }
+    }
+  }
+
+  const [state, formAction, pending] = useActionState<LoginFormState, FormData>(
+    loginAction,
+    {},
+  )
+
+  return (
+    <form
+      action={formAction}
+      className="space-y-4 [&_input]:bg-neutral-100 [&_input]:focus-visible:bg-transparent"
+    >
+      <div className="space-y-1 text-left">
+        <Input
+          name="email"
+          type="email"
+          autoComplete="email"
+          placeholder="Email address"
+          defaultValue={state.values?.email}
+          aria-invalid={Boolean(state.fieldErrors?.email)}
+        />
+        {state.fieldErrors?.email && (
+          <p className="text-sm text-red-500">{state.fieldErrors.email}</p>
+        )}
+      </div>
+
+      <div className="space-y-1 text-left">
+        <PasswordInput
+          name="password"
+          autoComplete="current-password"
+          placeholder="Password"
+          aria-invalid={Boolean(state.fieldErrors?.password)}
+        />
+        {state.fieldErrors?.password && (
+          <p className="text-sm text-red-500">{state.fieldErrors.password}</p>
+        )}
+      </div>
+
+      {state.error && (
+        <p role="alert" className="text-sm text-red-500">
+          {state.error}
+        </p>
+      )}
+
+      <div className="flex flex-col gap-4 pt-2">
+        <Button type="submit" full disabled={pending}>
+          {pending ? 'Signing in…' : 'Continue'}
+        </Button>
+        <Button
+          variant="outline"
+          type="button"
+          onClick={() => navigate({ to: '/' })}
+        >
+          Back
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/client/src/features/auth/components/signup-form.test.tsx
+++ b/client/src/features/auth/components/signup-form.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ApiError } from '#/lib/api'
+
+import { SignupForm } from './signup-form'
+
+const mockMutateAsync = vi.fn()
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+}))
+
+vi.mock('../auth.query', () => ({
+  useSignupMutation: () => ({ mutateAsync: mockMutateAsync }),
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+function fill(fields: {
+  firstName?: string
+  lastName?: string
+  email?: string
+  password?: string
+}) {
+  if (fields.firstName !== undefined) {
+    fireEvent.change(screen.getByPlaceholderText('First name'), {
+      target: { value: fields.firstName },
+    })
+  }
+  if (fields.lastName !== undefined) {
+    fireEvent.change(screen.getByPlaceholderText('Last name'), {
+      target: { value: fields.lastName },
+    })
+  }
+  if (fields.email !== undefined) {
+    fireEvent.change(screen.getByPlaceholderText('Email address'), {
+      target: { value: fields.email },
+    })
+  }
+  if (fields.password !== undefined) {
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: fields.password },
+    })
+  }
+}
+
+function submit() {
+  const form = screen.getByRole('button', { name: /continue/i }).closest('form')
+  if (!form) throw new Error('form not found')
+  fireEvent.submit(form)
+}
+
+describe('SignupForm', () => {
+  it('shows field errors and does not call the mutation on invalid input', async () => {
+    render(<SignupForm />)
+    fill({ firstName: '', lastName: '', email: 'bad', password: 'short' })
+    submit()
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid email/i)).toBeTruthy()
+    })
+    expect(mockMutateAsync).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('creates the account and navigates home when a session is returned', async () => {
+    mockMutateAsync.mockResolvedValueOnce({
+      user: { id: '1', email: 'user@example.com' },
+      session: { access_token: 'a', refresh_token: 'r' },
+    })
+    render(<SignupForm />)
+    fill({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'user@example.com',
+      password: 'supersecret',
+    })
+    submit()
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        email: 'user@example.com',
+        password: 'supersecret',
+      })
+    })
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/' })
+    })
+  })
+
+  it('routes to login when no session is returned (email confirmation)', async () => {
+    mockMutateAsync.mockResolvedValueOnce({
+      user: { id: '1', email: 'user@example.com' },
+      session: null,
+    })
+    render(<SignupForm />)
+    fill({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'user@example.com',
+      password: 'supersecret',
+    })
+    submit()
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/login' })
+    })
+  })
+
+  it('surfaces the server error message when the mutation rejects', async () => {
+    mockMutateAsync.mockRejectedValueOnce(
+      new ApiError('Email already registered', 409),
+    )
+    render(<SignupForm />)
+    fill({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'user@example.com',
+      password: 'supersecret',
+    })
+    submit()
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toBe(
+        'Email already registered',
+      )
+    })
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+})

--- a/client/src/features/auth/components/signup-form.tsx
+++ b/client/src/features/auth/components/signup-form.tsx
@@ -1,0 +1,158 @@
+import { useNavigate } from '@tanstack/react-router'
+import { useActionState } from 'react'
+import { z } from 'zod'
+
+import { Button } from '#/components/ui/button'
+import { Input } from '#/components/ui/input'
+import { PasswordInput } from '#/components/ui/password-input'
+import { isApiError } from '#/lib/api'
+
+import { useSignupMutation } from '../auth.query'
+import { signupRequestSchema } from '../auth.types'
+
+type SignupFormState = {
+  error?: string
+  fieldErrors?: {
+    firstName?: string
+    lastName?: string
+    email?: string
+    password?: string
+  }
+  values?: { firstName: string; lastName: string; email: string }
+}
+
+export function SignupForm() {
+  const navigate = useNavigate()
+  const signupMutation = useSignupMutation()
+
+  async function signupAction(
+    _previousState: SignupFormState,
+    formData: FormData,
+  ): Promise<SignupFormState> {
+    const firstName = String(formData.get('firstName') ?? '')
+    const lastName = String(formData.get('lastName') ?? '')
+    const email = String(formData.get('email') ?? '')
+    const password = String(formData.get('password') ?? '')
+
+    const values = { firstName, lastName, email }
+
+    const parsed = signupRequestSchema.safeParse({
+      firstName,
+      lastName,
+      email,
+      password,
+    })
+    if (!parsed.success) {
+      const { fieldErrors } = z.flattenError(parsed.error)
+      return {
+        values,
+        fieldErrors: {
+          firstName: fieldErrors.firstName?.[0],
+          lastName: fieldErrors.lastName?.[0],
+          email: fieldErrors.email?.[0],
+          password: fieldErrors.password?.[0],
+        },
+      }
+    }
+
+    try {
+      const response = await signupMutation.mutateAsync(parsed.data)
+      await navigate({ to: response.session ? '/' : '/login' })
+      return {}
+    } catch (error) {
+      return {
+        values,
+        error: isApiError(error)
+          ? error.message
+          : 'Unable to create your account. Please try again.',
+      }
+    }
+  }
+
+  const [state, formAction, pending] = useActionState<
+    SignupFormState,
+    FormData
+  >(signupAction, {})
+
+  return (
+    <form
+      action={formAction}
+      className="space-y-4 [&_input]:bg-neutral-100 [&_input]:focus-visible:bg-transparent"
+    >
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1 text-left">
+          <Input
+            name="firstName"
+            autoComplete="given-name"
+            placeholder="First name"
+            defaultValue={state.values?.firstName}
+            aria-invalid={Boolean(state.fieldErrors?.firstName)}
+          />
+          {state.fieldErrors?.firstName && (
+            <p className="text-sm text-red-500">
+              {state.fieldErrors.firstName}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1 text-left">
+          <Input
+            name="lastName"
+            autoComplete="family-name"
+            placeholder="Last name"
+            defaultValue={state.values?.lastName}
+            aria-invalid={Boolean(state.fieldErrors?.lastName)}
+          />
+          {state.fieldErrors?.lastName && (
+            <p className="text-sm text-red-500">{state.fieldErrors.lastName}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-1 text-left">
+        <Input
+          name="email"
+          type="email"
+          autoComplete="email"
+          placeholder="Email address"
+          defaultValue={state.values?.email}
+          aria-invalid={Boolean(state.fieldErrors?.email)}
+        />
+        {state.fieldErrors?.email && (
+          <p className="text-sm text-red-500">{state.fieldErrors.email}</p>
+        )}
+      </div>
+
+      <div className="space-y-1 text-left">
+        <PasswordInput
+          name="password"
+          autoComplete="new-password"
+          placeholder="Password"
+          aria-invalid={Boolean(state.fieldErrors?.password)}
+        />
+        {state.fieldErrors?.password && (
+          <p className="text-sm text-red-500">{state.fieldErrors.password}</p>
+        )}
+      </div>
+
+      {state.error && (
+        <p role="alert" className="text-sm text-red-500">
+          {state.error}
+        </p>
+      )}
+
+      <div className="flex flex-col gap-4 pt-2">
+        <Button type="submit" full disabled={pending}>
+          {pending ? 'Creating account…' : 'Continue'}
+        </Button>
+        <Button
+          variant="outline"
+          type="button"
+          onClick={() => navigate({ to: '/' })}
+        >
+          Back
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/client/src/features/auth/pages/login-page.tsx
+++ b/client/src/features/auth/pages/login-page.tsx
@@ -1,7 +1,18 @@
+import { LoginForm } from '../components/login-form'
+
 export function LoginPage() {
   return (
-    <div>
-      <h1>Login</h1>
-    </div>
+    <section
+      className="content-grid min-h-svh place-content-center space-y-6 py-6 text-center leading-[150%] text-neutral-700"
+      style={{ '--content-max-width': '35rem' } as React.CSSProperties}
+    >
+      <hgroup>
+        <h1 className="mb-0.5 text-2xl font-medium text-neutral-900">
+          Sign In
+        </h1>
+        <h2>Log in to access your account and continue your journey!</h2>
+      </hgroup>
+      <LoginForm />
+    </section>
   )
 }

--- a/client/src/features/auth/pages/signup-page.tsx
+++ b/client/src/features/auth/pages/signup-page.tsx
@@ -1,7 +1,25 @@
+import { Link } from '@tanstack/react-router'
+
+import { SignupForm } from '../components/signup-form'
+
 export function SignupPage() {
   return (
-    <div>
-      <h1>Signup</h1>
-    </div>
+    <section
+      className="content-grid min-h-svh place-content-center space-y-6 py-6 text-center leading-[150%] text-neutral-700"
+      style={{ '--content-max-width': '35rem' } as React.CSSProperties}
+    >
+      <hgroup>
+        <h1 className="mb-0.5 text-2xl font-medium text-neutral-900">
+          Create your account
+        </h1>
+        <h2>Join us today and create your account to begin your journey!</h2>
+      </hgroup>
+      <SignupForm />
+      <p className="[&_a]:text-purple-500 [&_a]:underline [&_a]:underline-offset-2">
+        By clicking Continue, you acknowledge that you have read and agree with
+        Ekehi&apos;s <Link to="/">Terms</Link> and{' '}
+        <Link to="/">Privacy Policy</Link>
+      </p>
+    </section>
   )
 }

--- a/client/src/routes/(auth)/login.tsx
+++ b/client/src/routes/(auth)/login.tsx
@@ -5,6 +5,9 @@ import { pageMeta } from '#/lib/page-meta'
 
 export const Route = createFileRoute('/(auth)/login')({
   component: LoginPage,
+  validateSearch: (search: Record<string, unknown>): { redirect?: string } => ({
+    redirect: typeof search.redirect === 'string' ? search.redirect : undefined,
+  }),
   head: () =>
     pageMeta({
       title: 'Log in',

--- a/client/src/test/setup.ts
+++ b/client/src/test/setup.ts
@@ -1,0 +1,6 @@
+import { cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+afterEach(() => {
+  cleanup()
+})

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -16,6 +16,11 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
+    test: {
+      environment: 'jsdom',
+      globals: true,
+      setupFiles: ['./src/test/setup.ts'],
+    },
     resolve: { tsconfigPaths: true },
     plugins: [
       devtools(),


### PR DESCRIPTION
## Summary
Makes the login and signup forms functional. Both forms now run through React 19 `useActionState` into the existing TanStack Query auth mutations (`useLoginMutation` / `useSignupMutation`), with Zod validation, inline field errors, and server-error surfacing.

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Linked Issue
Closes #143

## Changes Made
- Wire `LoginForm` to `useLoginMutation` via `useActionState`; validate with `loginRequestSchema`, surface field + server errors.
- Honor the `redirect` search param via `validateSearch` on the `(auth)/login` route so post-login returns the user to their original destination.
- Wire `SignupForm` (first name, last name, email, password) to `useSignupMutation`; navigate home when a session is returned, to `/login` for email-confirmation signups.
- Build out the signup page layout and copy.
- Stand up the Vitest harness (config + `src/test/setup.ts`) and add gate tests for both forms.
- Gate `test` inside the `check` script (`lint → typecheck → test → format:check`).

## Screenshots (for UI changes)
<img width="1532" height="920" alt="Screenshot 2026-06-17 at 8 47 25 PM" src="https://github.com/user-attachments/assets/86bea5d7-e0db-4fa0-884c-85e7fb0a0fd0" />
<img width="1532" height="920" alt="Screenshot 2026-06-17 at 8 47 41 PM" src="https://github.com/user-attachments/assets/a832537e-e5e0-4702-ba2e-73d4dd60ebb1" />


## Checklist
- [x] Branch is up to date with `development`
- [x] `pnpm check` passes locally (lint + typecheck + format)
- [x] Commit messages follow Conventional Commits
- [x] No `.env` or secrets committed
- [x] UI changes tested on mobile and desktop _(desktop verified; mobile pending)_
- [ ] Backend changes tested locally _(N/A — client only)_
- [x] PR is linked to an issue
