### PR TITLE
Build template detail page

### DIFF
--- a/client/src/config/endpoints.ts
+++ b/client/src/config/endpoints.ts
@@ -12,4 +12,8 @@ export const ENDPOINTS = {
     list: '/guides',
     byId: (id: string) => `/guides/${id}`,
   },
+  templates: {
+    list: '/templates',
+    byId: (id: string) => `/templates/${id}`,
+  },
 } as const

--- a/client/src/features/resources/pages/template-detail-page.test.tsx
+++ b/client/src/features/resources/pages/template-detail-page.test.tsx
@@ -38,8 +38,6 @@ describe('TemplateDetailPage', () => {
 
     render(<TemplateDetailPage id={mockId} />)
 
-    // TemplateSkeleton renders its placeholder blocks with aria-hidden,
-    // so we assert on the absence of real content instead of querying text.
     expect(screen.queryByRole('heading')).toBeNull()
   })
 
@@ -98,17 +96,18 @@ describe('TemplateDetailPage', () => {
     expect(screen.getByText('Something went wrong')).toBeTruthy()
   })
 
-  it('renders the template title, category, description, content, and created date on success', () => {
+  it('renders title, category, description, and formatted created date on success', () => {
     vi.mocked(useTemplateQuery).mockReturnValue({
       data: {
         id: mockId,
-        title: 'Pitch Deck Template',
-        description: 'A clean starting point for your fundraising pitch.',
-        category: 'Fundraising',
-        content: 'Slide 1: Problem\nSlide 2: Solution',
+        title: 'Basic financial management template',
+        description:
+          'Explore our Basic Financial Management Template designed for SMEs.',
+        category: 'finance',
+        content: null,
         file_url: null,
-        created_at: '2026-01-15T00:00:00.000Z',
-        updated_at: '2026-01-15T00:00:00.000Z',
+        created_at: '2026-03-26T00:00:00.000Z',
+        updated_at: '2026-03-26T00:00:00.000Z',
       },
       isLoading: false,
       error: null,
@@ -116,16 +115,111 @@ describe('TemplateDetailPage', () => {
 
     render(<TemplateDetailPage id={mockId} />)
 
-    expect(screen.getByText('Pitch Deck Template')).toBeTruthy()
-    expect(screen.getByText('Fundraising')).toBeTruthy()
+    expect(screen.getByText('Basic financial management template')).toBeTruthy()
+    expect(screen.getByText('finance')).toBeTruthy()
     expect(
-      screen.getByText('A clean starting point for your fundraising pitch.'),
+      screen.getByText(/Explore our Basic Financial Management Template/i),
     ).toBeTruthy()
-    expect(screen.getByText(/Slide 1: Problem/)).toBeTruthy()
-    expect(screen.getByText(/15 January 2026/)).toBeTruthy()
+    expect(screen.getByText(/26 March 2026/)).toBeTruthy()
   })
 
-  it('shows the "Open template" link only when file_url is present', () => {
+  it('parses JSON content into formatted sections instead of showing the raw string', () => {
+    const rawContent = JSON.stringify({
+      author: 'Fisayo Rotibi',
+      sections: [
+        {
+          heading: null,
+          body: 'Managing your business finances does not have to be complicated.',
+        },
+        {
+          heading: 'What this template includes',
+          body: 'The template covers five core areas.',
+        },
+      ],
+    })
+
+    vi.mocked(useTemplateQuery).mockReturnValue({
+      data: {
+        id: mockId,
+        title: 'Basic financial management template',
+        description: null,
+        category: 'finance',
+        content: rawContent,
+        file_url: null,
+        created_at: '2026-03-26T00:00:00.000Z',
+        updated_at: '2026-03-26T00:00:00.000Z',
+      },
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<TemplateDetailPage id={mockId} />)
+
+    // The raw JSON string itself should never appear on screen.
+    expect(screen.queryByText(/"author":/)).toBeNull()
+
+    // The parsed sections should render as real headings and paragraphs.
+    expect(screen.getByText('What this template includes')).toBeTruthy()
+    expect(
+      screen.getByText(
+        /Managing your business finances does not have to be complicated/i,
+      ),
+    ).toBeTruthy()
+    expect(
+      screen.getByText(/The template covers five core areas/i),
+    ).toBeTruthy()
+  })
+
+  it('renders the author line on the sidebar card when content includes an author', () => {
+    const rawContent = JSON.stringify({
+      author: 'Fisayo Rotibi',
+      sections: [{ heading: null, body: 'Some body text.' }],
+    })
+
+    vi.mocked(useTemplateQuery).mockReturnValue({
+      data: {
+        id: mockId,
+        title: 'Basic financial management template',
+        description: null,
+        category: 'finance',
+        content: rawContent,
+        file_url: null,
+        created_at: '2026-03-26T00:00:00.000Z',
+        updated_at: '2026-03-26T00:00:00.000Z',
+      },
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<TemplateDetailPage id={mockId} />)
+
+    expect(screen.getByText('with Fisayo Rotibi')).toBeTruthy()
+  })
+
+  it('falls back to a single plain section when content is not valid JSON', () => {
+    vi.mocked(useTemplateQuery).mockReturnValue({
+      data: {
+        id: mockId,
+        title: 'Legacy plain text template',
+        description: null,
+        category: null,
+        content: 'Just a plain string, not JSON at all.',
+        file_url: null,
+        created_at: '2026-03-26T00:00:00.000Z',
+        updated_at: '2026-03-26T00:00:00.000Z',
+      },
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<TemplateDetailPage id={mockId} />)
+
+    expect(
+      screen.getByText('Just a plain string, not JSON at all.'),
+    ).toBeTruthy()
+  })
+
+  it('shows the "Download template" link only when file_url is present', () => {
     vi.mocked(useTemplateQuery).mockReturnValue({
       data: {
         id: mockId,
@@ -143,8 +237,8 @@ describe('TemplateDetailPage', () => {
 
     render(<TemplateDetailPage id={mockId} />)
 
-    const openLink = screen.getByText('Download template')
-    expect(openLink.closest('a')?.getAttribute('href')).toBe(
+    const downloadLink = screen.getByText('Download template')
+    expect(downloadLink.closest('a')?.getAttribute('href')).toBe(
       'https://example.com/template.pdf',
     )
   })

--- a/client/src/features/resources/pages/template-detail-page.test.tsx
+++ b/client/src/features/resources/pages/template-detail-page.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { isApiError } from '#/lib/api'
+
+import { useTemplateQuery } from '../resources.query'
+import { TemplateDetailPage } from './template-detail-page'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, children, className, ...props }: any) => (
+    <a href={to} className={className} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('../resources.query', () => ({
+  useTemplateQuery: vi.fn(),
+}))
+
+vi.mock('#/lib/api', () => ({
+  isApiError: vi.fn(),
+}))
+
+describe('TemplateDetailPage', () => {
+  const mockId = 'test-template-123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the loading skeleton while the query is in flight', () => {
+    vi.mocked(useTemplateQuery).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as any)
+
+    render(<TemplateDetailPage id={mockId} />)
+
+    // TemplateSkeleton renders its placeholder blocks with aria-hidden,
+    // so we assert on the absence of real content instead of querying text.
+    expect(screen.queryByRole('heading')).toBeNull()
+  })
+
+  it('renders a "Template not found" message and back link on a 404 error', () => {
+    const mockError = { status: 404, message: 'Not found' }
+
+    vi.mocked(useTemplateQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: mockError,
+    } as any)
+
+    vi.mocked(isApiError).mockReturnValue(true)
+
+    render(<TemplateDetailPage id={mockId} />)
+
+    expect(screen.getByText('Template not found')).toBeTruthy()
+    expect(
+      screen.getByText(/We couldn't find the template you're looking for/i),
+    ).toBeTruthy()
+
+    const backLink = screen.getByText('← Back to templates')
+    expect(backLink.getAttribute('href')).toBe('/resources/templates')
+  })
+
+  it('renders a generic error message for non-404 errors', () => {
+    const mockError = { status: 500, message: 'Server exploded' }
+
+    vi.mocked(useTemplateQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: mockError,
+    } as any)
+
+    vi.mocked(isApiError).mockReturnValue(true)
+
+    render(<TemplateDetailPage id={mockId} />)
+
+    expect(screen.getByText('Something went wrong')).toBeTruthy()
+    expect(
+      screen.getByText(/There was a problem loading this template/i),
+    ).toBeTruthy()
+  })
+
+  it('renders a generic error message when the error is not an ApiError at all', () => {
+    vi.mocked(useTemplateQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network down'),
+    } as any)
+
+    vi.mocked(isApiError).mockReturnValue(false)
+
+    render(<TemplateDetailPage id={mockId} />)
+
+    expect(screen.getByText('Something went wrong')).toBeTruthy()
+  })
+
+  it('renders the template title, category, description, content, and created date on success', () => {
+    vi.mocked(useTemplateQuery).mockReturnValue({
+      data: {
+        id: mockId,
+        title: 'Pitch Deck Template',
+        description: 'A clean starting point for your fundraising pitch.',
+        category: 'Fundraising',
+        content: 'Slide 1: Problem\nSlide 2: Solution',
+        file_url: null,
+        created_at: '2026-01-15T00:00:00.000Z',
+        updated_at: '2026-01-15T00:00:00.000Z',
+      },
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<TemplateDetailPage id={mockId} />)
+
+    expect(screen.getByText('Pitch Deck Template')).toBeTruthy()
+    expect(screen.getByText('Fundraising')).toBeTruthy()
+    expect(
+      screen.getByText('A clean starting point for your fundraising pitch.'),
+    ).toBeTruthy()
+    expect(screen.getByText(/Slide 1: Problem/)).toBeTruthy()
+    expect(screen.getByText(/15 January 2026/)).toBeTruthy()
+  })
+
+  it('shows the "Open template" link only when file_url is present', () => {
+    vi.mocked(useTemplateQuery).mockReturnValue({
+      data: {
+        id: mockId,
+        title: 'Template With File',
+        description: null,
+        category: null,
+        content: null,
+        file_url: 'https://example.com/template.pdf',
+        created_at: '2026-01-15T00:00:00.000Z',
+        updated_at: '2026-01-15T00:00:00.000Z',
+      },
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<TemplateDetailPage id={mockId} />)
+
+    const openLink = screen.getByText('Download template')
+    expect(openLink.closest('a')?.getAttribute('href')).toBe(
+      'https://example.com/template.pdf',
+    )
+  })
+
+  it('does not render the "Download template" link when file_url is null', () => {
+    vi.mocked(useTemplateQuery).mockReturnValue({
+      data: {
+        id: mockId,
+        title: 'Template Without File',
+        description: null,
+        category: null,
+        content: null,
+        file_url: null,
+        created_at: '2026-01-15T00:00:00.000Z',
+        updated_at: '2026-01-15T00:00:00.000Z',
+      },
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<TemplateDetailPage id={mockId} />)
+
+    expect(screen.queryByText('Download template')).toBeNull()
+  })
+})

--- a/client/src/features/resources/pages/template-detail-page.tsx
+++ b/client/src/features/resources/pages/template-detail-page.tsx
@@ -1,10 +1,41 @@
 import { Link } from '@tanstack/react-router'
 
+import { IMAGES } from '#/assets/images'
 import { Button } from '#/components/ui/button'
 import { TemplateSkeleton } from '#/components/ui/skeleton'
 import { isApiError } from '#/lib/api'
 
 import { useTemplateQuery } from '../resources.query'
+
+// The `content` field comes back from the API as a JSON-encoded string
+// shaped like: { "author": "...", "sections": [{ "heading": "...", "body": "..." }] }
+// This mirrors how GuideDetailPage parses its own `content` field.
+interface TemplateSection {
+  heading: string | null
+  body: string
+}
+
+interface ParsedTemplateContent {
+  author?: string
+  sections: Array<TemplateSection>
+}
+
+function parseTemplateContent(
+  raw: string | null,
+): ParsedTemplateContent | null {
+  if (!raw) return null
+
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed && Array.isArray(parsed.sections)) {
+      return { author: parsed.author, sections: parsed.sections }
+    }
+    return null
+  } catch {
+    // If content isn't valid JSON, fall back to treating it as one plain section.
+    return { sections: [{ heading: null, body: raw }] }
+  }
+}
 
 function formatDate(dateString: string) {
   return new Date(dateString).toLocaleDateString('en-GB', {
@@ -14,12 +45,19 @@ function formatDate(dateString: string) {
   })
 }
 
+const CATEGORY_COLORS: Record<string, { bg: string; text: string }> = {
+  finance: { bg: '#26B3B5', text: '#033F25' },
+  tax: { bg: '#e91e8c', text: '#341539' },
+  export: { bg: '#4caf50', text: '#033F25' },
+}
+const DEFAULT_CATEGORY_COLOR = { bg: '#6366f1', text: '#1e1b4b' }
+
 export function TemplateDetailPage({ id }: { id: string }) {
   const { data: template, isLoading, error } = useTemplateQuery(id)
 
   if (isLoading) {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12">
+      <div className="mx-auto max-w-6xl px-6 py-12 lg:px-16">
         <TemplateSkeleton />
       </div>
     )
@@ -52,50 +90,104 @@ export function TemplateDetailPage({ id }: { id: string }) {
     return null
   }
 
+  const parsedContent = parseTemplateContent(template.content)
+  const colors = template.category
+    ? (CATEGORY_COLORS[template.category] ?? DEFAULT_CATEGORY_COLOR)
+    : DEFAULT_CATEGORY_COLOR
+
   return (
-    <div className="mx-auto flex max-w-3xl flex-col gap-6 px-6 py-12">
+    <div className="mx-auto max-w-6xl px-6 py-12 lg:px-16">
       <Link
         to="/resources/templates"
-        className="text-content-secondary hover:text-content text-sm font-medium"
+        className="text-content-secondary hover:text-content mb-6 inline-block text-sm font-medium"
       >
         ← Back to templates
       </Link>
 
-      <div className="flex flex-col gap-3">
-        {template.category && (
-          <span className="bg-surface-subtle text-content-secondary w-fit rounded-full px-3 py-1 text-xs font-medium">
-            {template.category}
-          </span>
-        )}
+      <div className="grid grid-cols-1 gap-10 lg:grid-cols-[1fr_320px]">
+        {/* Left: main content */}
+        <div className="flex flex-col gap-4">
+          {template.category && (
+            <span className="bg-surface-subtle text-content-secondary w-fit rounded-full px-3 py-1 text-xs font-medium">
+              {template.category}
+            </span>
+          )}
 
-        <h1 className="text-content font-serif text-3xl sm:text-4xl">
-          {template.title}
-        </h1>
+          <h1 className="text-content font-serif text-3xl sm:text-4xl">
+            {template.title}
+          </h1>
 
-        {template.description && (
-          <p className="text-content-secondary text-base">
-            {template.description}
+          {template.description && (
+            <p className="text-content-secondary text-base">
+              {template.description}
+            </p>
+          )}
+
+          <p className="text-content-muted text-xs">
+            Added {formatDate(template.created_at)}
           </p>
-        )}
 
-        <p className="text-content-muted text-xs">
-          Added {formatDate(template.created_at)}
-        </p>
-      </div>
+          {/* Parsed, formatted sections — not the raw JSON string */}
+          {parsedContent && parsedContent.sections.length > 0 && (
+            <div className="mt-2 flex flex-col gap-6">
+              {parsedContent.sections.map((section, index) => (
+                <div key={index}>
+                  {section.heading && (
+                    <h2 className="text-content mb-2 text-base font-semibold">
+                      {section.heading}
+                    </h2>
+                  )}
+                  <p className="text-content-secondary text-sm leading-relaxed sm:text-base">
+                    {section.body}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
 
-      {template.content && (
-        <div className="text-content text-sm leading-relaxed whitespace-pre-wrap sm:text-base">
-          {template.content}
+          {template.file_url && (
+            <Button asChild variant="primary" size="md" className="mt-2 w-fit">
+              <a
+                href={template.file_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Download template
+              </a>
+            </Button>
+          )}
         </div>
-      )}
 
-      {template.file_url && (
-        <Button asChild variant="primary" size="md" className="w-fit">
-          <a href={template.file_url} target="_blank" rel="noopener noreferrer">
-            Download template
-          </a>
-        </Button>
-      )}
+        {/* Right: dynamic colour-coded card with cover image + author */}
+        <aside className="h-fit">
+          <div
+            className="flex flex-col gap-4 rounded-2xl p-5"
+            style={{ backgroundColor: colors.bg }}
+          >
+            <h3
+              className="font-serif text-lg leading-snug"
+              style={{ color: colors.text }}
+            >
+              {template.title}
+            </h3>
+
+            <img
+              src={IMAGES.blackWomanWearingGlasses}
+              alt={template.title}
+              className="w-full rounded-xl object-cover"
+            />
+
+            {parsedContent?.author && (
+              <span
+                className="text-sm font-medium"
+                style={{ color: colors.text }}
+              >
+                with {parsedContent.author}
+              </span>
+            )}
+          </div>
+        </aside>
+      </div>
     </div>
   )
 }

--- a/client/src/features/resources/pages/template-detail-page.tsx
+++ b/client/src/features/resources/pages/template-detail-page.tsx
@@ -1,7 +1,101 @@
+import { Link } from '@tanstack/react-router'
+
+import { Button } from '#/components/ui/button'
+import { TemplateSkeleton } from '#/components/ui/skeleton'
+import { isApiError } from '#/lib/api'
+
+import { useTemplateQuery } from '../resources.query'
+
+function formatDate(dateString: string) {
+  return new Date(dateString).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+}
+
 export function TemplateDetailPage({ id }: { id: string }) {
+  const { data: template, isLoading, error } = useTemplateQuery(id)
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-3xl px-6 py-12">
+        <TemplateSkeleton />
+      </div>
+    )
+  }
+
+  if (error) {
+    const notFound = isApiError(error) && error.status === 404
+
+    return (
+      <div className="mx-auto flex max-w-3xl flex-col items-center gap-4 px-6 py-20 text-center">
+        <h1 className="text-content text-xl font-semibold">
+          {notFound ? 'Template not found' : 'Something went wrong'}
+        </h1>
+        <p className="text-content-secondary">
+          {notFound
+            ? "We couldn't find the template you're looking for. It may have been removed or the link may be incorrect."
+            : 'There was a problem loading this template. Please try again shortly.'}
+        </p>
+        <Link
+          to="/resources/templates"
+          className="text-primary hover:text-primary-hover text-sm font-medium"
+        >
+          ← Back to templates
+        </Link>
+      </div>
+    )
+  }
+
+  if (!template) {
+    return null
+  }
+
   return (
-    <div>
-      <h1>Template · {id}</h1>
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 px-6 py-12">
+      <Link
+        to="/resources/templates"
+        className="text-content-secondary hover:text-content text-sm font-medium"
+      >
+        ← Back to templates
+      </Link>
+
+      <div className="flex flex-col gap-3">
+        {template.category && (
+          <span className="bg-surface-subtle text-content-secondary w-fit rounded-full px-3 py-1 text-xs font-medium">
+            {template.category}
+          </span>
+        )}
+
+        <h1 className="text-content font-serif text-3xl sm:text-4xl">
+          {template.title}
+        </h1>
+
+        {template.description && (
+          <p className="text-content-secondary text-base">
+            {template.description}
+          </p>
+        )}
+
+        <p className="text-content-muted text-xs">
+          Added {formatDate(template.created_at)}
+        </p>
+      </div>
+
+      {template.content && (
+        <div className="text-content text-sm leading-relaxed whitespace-pre-wrap sm:text-base">
+          {template.content}
+        </div>
+      )}
+
+      {template.file_url && (
+        <Button asChild variant="primary" size="md" className="w-fit">
+          <a href={template.file_url} target="_blank" rel="noopener noreferrer">
+            Download template
+          </a>
+        </Button>
+      )}
     </div>
   )
 }

--- a/client/src/features/resources/resources.query.ts
+++ b/client/src/features/resources/resources.query.ts
@@ -1,13 +1,24 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { GuidesService } from './resources.service'
-import type { GuideResponse } from './resources.types'
+import { GuidesService, TemplatesService } from './resources.service'
+import type { GuideResponse, TemplateResponse } from './resources.types'
 
 export function useGuideQuery(id: string) {
   return useQuery<GuideResponse, Error>({
     queryKey: ['guide', id] as const,
     queryFn: async () => {
       const response = await GuidesService.byId(id)
+      return response.data
+    },
+    enabled: !!id,
+  })
+}
+
+export function useTemplateQuery(id: string) {
+  return useQuery<TemplateResponse, Error>({
+    queryKey: ['template', id] as const,
+    queryFn: async () => {
+      const response = await TemplatesService.byId(id)
       return response.data
     },
     enabled: !!id,

--- a/client/src/features/resources/resources.service.ts
+++ b/client/src/features/resources/resources.service.ts
@@ -1,7 +1,7 @@
 import { ENDPOINTS } from '#/config/endpoints'
 import { makeRequest } from '#/lib/api'
 
-import type { GuideResponse } from './resources.types'
+import type { GuideResponse, TemplateResponse } from './resources.types'
 
 export const GuidesService = {
   byId: (id: string) => {
@@ -10,5 +10,15 @@ export const GuidesService = {
       'GET',
     )
     return guideRequest()
+  },
+}
+
+export const TemplatesService = {
+  byId: (id: string) => {
+    const templateRequest = makeRequest<TemplateResponse, void>(
+      ENDPOINTS.templates.byId(id),
+      'GET',
+    )
+    return templateRequest()
   },
 }

--- a/client/src/features/resources/resources.types.ts
+++ b/client/src/features/resources/resources.types.ts
@@ -14,3 +14,16 @@ export const guideResponseSchema = z.object({
 })
 
 export type GuideResponse = z.infer<typeof guideResponseSchema>
+
+export const templateResponseSchema = z.object({
+  id: z.string(),
+  title: z.string().trim().min(1),
+  description: z.string().nullable(),
+  category: z.string().nullable(),
+  content: z.string().nullable(),
+  file_url: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export type TemplateResponse = z.infer<typeof templateResponseSchema>


### PR DESCRIPTION
## Summary
This PR builds the templates detail page in the React/TS client, replacing the stub component. Fetches a template by id from the existing API and renders it with proper loading, not-found, and error states, mirroring the guides detail pattern. Adds the templates data layer (types, service, query) alongside the existing guides data layer in resources.types.ts, resources.service.ts, and resources.query.ts.

## Type of Change
- [x] Feature

## Linked Issue
Closes #159

## Changes Made
- Added templateResponseSchema and TemplateResponse type to resources.types.ts
- Added TemplatesService.byId to resources.service.ts using makeRequest 
  (GET /templates/:id)
- Added useTemplateQuery(id) hook to resources.query.ts using TanStack Query, 
  no useEffect
- Added templates.byId entry to config/endpoints.ts
- Replaced the template-detail-page.tsx stub with a full implementation:
  - Loading state renders TemplateSkeleton
  - 404 errors (isApiError(error) && error.status === 404) render a 
    "Template not found" message with a back link
  - Other errors render a generic error message
  - Success renders title, category, description, content 
    (whitespace-pre-wrap), formatted created_at, and a "Download template" 
    link (Button asChild + <a href={file_url}>) shown only when file_url exists
  - Back link to /resources/templates on both error and success states
- Added template-detail-page.test.tsx covering loading, 404, generic error, 
  non-ApiError error, success with all fields, and conditional file_url link

## Screenshots (for UI changes)
<!-- Add before/after screenshots or a screen recording -->

## Checklist
- [x] Branch is up to date with development
- [x] pnpm check passes locally
- [x] Commit messages follow Conventional Commits
- [x] No .env files or secrets committed
- [x] UI changes tested on mobile and desktop
- [ ] Backend changes tested locally with Postman or curl
- [x] PR is linked to a GitHub issue