### PR TITLE
Fix (bug): Hero section and navbar to match figma design

### DIFF
--- a/client/src/components/layout/navbar.tsx
+++ b/client/src/components/layout/navbar.tsx
@@ -109,21 +109,24 @@ export const Navbar: React.FC = () => {
     'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?auto=format&fit=crop&q=80&w=120'
 
   return (
-    <div className="w-full font-sans" ref={innerRef}>
-      <nav className="relative border-b border-gray-100 bg-white">
+    <div
+      className="absolute inset-x-0 top-0 z-50 w-full font-sans"
+      ref={innerRef}
+    >
+      <nav className="relative">
         <div className="mx-auto flex h-20 max-w-7xl items-center justify-between px-6">
           <Link
             to={logo.to}
-            className="flex cursor-pointer items-center space-x-3 text-[#4a0066]"
+            className="flex cursor-pointer items-center space-x-3 text-white"
             aria-label="Ekehi homepage"
           >
             <img
-              src={SVGS.ekehiLogo}
+              src={SVGS.ekehiLogo2}
               alt={logo.wordmark}
               width={43}
               height={48}
             />
-            <span className="font-serif text-2xl font-semibold tracking-wide italic">
+            <span className="font-serif text-2xl font-semibold tracking-wide text-white italic">
               {logo.wordmark}
             </span>
           </Link>
@@ -133,9 +136,9 @@ export const Navbar: React.FC = () => {
               <Link
                 key={item.label}
                 to={item.to}
-                activeProps={{ className: 'font-semibold text-[#7a0099]' }}
+                activeProps={{ className: 'font-semibold text-white' }}
                 inactiveProps={{
-                  className: 'text-gray-500 hover:text-gray-900',
+                  className: 'text-white/80 hover:text-white',
                 }}
                 className="text-sm font-medium transition-colors duration-200"
               >
@@ -149,13 +152,13 @@ export const Navbar: React.FC = () => {
               <>
                 <Link
                   to={cta.signup.to}
-                  className="rounded-full bg-[#4a0066] px-6 py-2.5 text-center text-sm font-medium text-white shadow-sm transition-colors hover:bg-[#36004d]"
+                  className="rounded-full bg-white px-6 py-2.5 text-center text-sm font-medium text-[#4a0066] shadow-sm transition-colors hover:bg-white/90"
                 >
                   {cta.signup.label}
                 </Link>
                 <Link
                   to={cta.login.to}
-                  className="rounded-full border border-[#4a0066] px-6 py-2.5 text-center text-sm font-medium text-[#4a0066] transition-colors hover:bg-purple-50"
+                  className="rounded-full border border-white px-6 py-2.5 text-center text-sm font-medium text-white transition-colors hover:bg-white/10"
                 >
                   {cta.login.label}
                 </Link>
@@ -209,7 +212,7 @@ export const Navbar: React.FC = () => {
                   ? 'Close navigation menu'
                   : 'Open navigation menu'
               }
-              className="text-gray-500 hover:text-gray-700 focus:outline-none"
+              className="text-white hover:text-white/80 focus:outline-none"
             >
               <svg
                 className="h-6 w-6"

--- a/client/src/features/site/components/hero.tsx
+++ b/client/src/features/site/components/hero.tsx
@@ -3,7 +3,7 @@ import { Button } from '#/components/ui/button'
 
 export function HeroSection() {
   return (
-    <section className="relative isolate flex min-h-[600px] w-full items-end overflow-hidden px-6 pt-24 pb-1 sm:px-10 sm:pt-32 md:px-16 md:pt-36 lg:min-h-[952px] lg:px-[146px] lg:pt-[180px]">
+    <section className="relative isolate flex min-h-[600px] w-full items-end overflow-hidden px-6 pb-10 sm:px-10 sm:pb-14 md:px-16 lg:min-h-[952px] lg:px-[146px] lg:pb-[64px]">
       {/* Background image */}
       <img
         src={IMAGES.headerImg}
@@ -19,12 +19,12 @@ export function HeroSection() {
       />
 
       {/* Content */}
-      <div className="flex w-full flex-col gap-6 pb-10 sm:flex-row sm:items-end sm:justify-between sm:gap-10 lg:pb-1">
+      <div className="flex w-full max-w-[1104px] flex-col gap-6 sm:flex-row sm:items-end sm:gap-16 lg:gap-[64px]">
         <h1 className="text-content-inverse max-w-[20ch] font-serif text-3xl leading-tight sm:text-4xl md:text-5xl">
           Find Funding and Resources Built for You
         </h1>
 
-        <div className="flex max-w-md flex-col gap-5">
+        <div className="flex max-w-sm flex-col gap-5">
           <p className="text-content-inverse/90 text-sm sm:text-base">
             Grants, loans, training programmes, and growth resources for
             women-led businesses — searchable and always up to date.


### PR DESCRIPTION
## Summary
Fixes the hero section so the background photo bleeds behind the navbar, matching the Figma design. The navbar is now transparent and absolutely positioned so it floats on top of the hero photo instead of pushing content down with a solid white background. Also adjusts the hero content's vertical spacing so the text sits higher in the section rather than crowding the bottom edge.

## Before and After
<img width="940" height="363" alt="Screenshot 2026-06-22 115900" src="https://github.com/user-attachments/assets/0f27b2ee-641b-4862-a026-1084af089673" />
<img width="932" height="427" alt="image" src="https://github.com/user-attachments/assets/21b97645-4fd9-47ed-aa1b-39824f86d0a3" />

## Type of Change
- [x] Bug fix

## Linked Issue
Related to #139

## Changes Made
- Changed navbar wrapper from static w-full to absolute inset-x-0 top-0 z-50, removing it from the normal page flow
- Removed bg-white and border-b from the navbar so the hero photo shows through behind it
- Updated logo, nav links, mobile menu icon, and CTA buttons to white/light colours for readability against the dark hero photo
- Removed top padding on the hero section that was previously reserved for navbar clearance, since the navbar no longer pushes content